### PR TITLE
refactor(core): clean up presentation, error handling, and dead code

### DIFF
--- a/dom/cli/_helpers.py
+++ b/dom/cli/_helpers.py
@@ -1,0 +1,42 @@
+"""Shared CLI helpers.
+
+Both contest and infrastructure CLI commands need the same shape:
+build a ``SecretsManager``, build a ``Context``, run a configuration
+load operation. Parameterizing on the operation factory collapses the
+two duplicate ``helpers.py`` modules into one.
+"""
+
+from collections.abc import Callable
+from pathlib import Path
+from typing import TypeVar
+
+from dom.core.operations import Context, run
+from dom.core.operations.framework import Operation
+from dom.types.secrets import SecretsProvider
+from dom.utils.cli import get_secrets_manager
+
+T = TypeVar("T")
+
+ConfigOpFactory = Callable[[Path | None], Operation[T]]
+
+
+def load_with_secrets(
+    config_op_factory: ConfigOpFactory[T],
+    file: Path | None,
+    verbose: bool = False,
+) -> tuple[T, SecretsProvider]:
+    """Run a configuration-loading operation and return ``(config, secrets)``.
+
+    ``config_op_factory`` is one of the ``load_*_op`` factories (e.g.
+    ``load_config_op``, ``load_infra_config_op``). It's called with
+    ``file`` to produce the bound :class:`Operation`. Raises
+    ``typer.Exit(1)`` on failure (propagated from :func:`run`).
+    """
+    secrets = get_secrets_manager()
+    config = run(config_op_factory(file), Context(secrets=secrets, verbose=verbose))
+    if config is None:
+        raise RuntimeError(
+            f"{config_op_factory.__name__} returned no value; "
+            "load operations must be single-step and produce a config object"
+        )
+    return config, secrets

--- a/dom/cli/contest/apply.py
+++ b/dom/cli/contest/apply.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import typer
 
 from dom.cli.contest.helpers import load_config_with_secrets
+from dom.cli.contest.render import render_apply_warnings
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.contest import apply_contests_op
@@ -26,4 +27,8 @@ def apply_command(
     Use ``--dry-run`` to preview the steps that would run.
     """
     config, secrets = load_config_with_secrets(file, verbose)
-    run(apply_contests_op(config), Context(secrets=secrets, dry_run=dry_run, verbose=verbose))
+    results = run(
+        apply_contests_op(config), Context(secrets=secrets, dry_run=dry_run, verbose=verbose)
+    )
+    if results:
+        render_apply_warnings(results)

--- a/dom/cli/contest/helpers.py
+++ b/dom/cli/contest/helpers.py
@@ -2,9 +2,8 @@
 
 from pathlib import Path
 
-from dom.core.operations import Context, run
+from dom.cli._helpers import load_with_secrets
 from dom.core.operations.contest import load_config_op
-from dom.utils.cli import get_secrets_manager
 
 
 def load_config_with_secrets(file: Path | None, verbose: bool = False):
@@ -12,7 +11,4 @@ def load_config_with_secrets(file: Path | None, verbose: bool = False):
 
     Returns ``(DomConfig, SecretsManager)``. Raises ``typer.Exit(1)`` on failure.
     """
-    secrets = get_secrets_manager()
-    ctx = Context(secrets=secrets, verbose=verbose)
-    config = run(load_config_op(file), ctx)
-    return config, secrets
+    return load_with_secrets(load_config_op, file, verbose)

--- a/dom/cli/contest/plan.py
+++ b/dom/cli/contest/plan.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import typer
 
 from dom.cli.contest.helpers import load_config_with_secrets
+from dom.cli.contest.render import render_planned_changes
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.contest import plan_contest_changes_op
@@ -26,4 +27,6 @@ def plan_command(
     and which problems/teams would be added.
     """
     config, secrets = load_config_with_secrets(file, verbose)
-    run(plan_contest_changes_op(config), Context(secrets=secrets, verbose=verbose))
+    changes = run(plan_contest_changes_op(config), Context(secrets=secrets, verbose=verbose))
+    if changes is not None:
+        render_planned_changes(changes)

--- a/dom/cli/contest/render.py
+++ b/dom/cli/contest/render.py
@@ -1,0 +1,84 @@
+"""CLI-side renderers for contest plan/apply output.
+
+Operations and services return structured data; this module renders it.
+Keeping presentation here means the core layers stay free of console
+concerns.
+"""
+
+from typing import Any
+
+from dom.core.services.contest.apply import ContestApplyResult
+from dom.core.services.contest.changes import ChangeType
+from dom.logging_config import console
+
+
+def render_planned_changes(changes: list[dict[str, Any]]) -> None:
+    if not changes:
+        console.print("\n[dim]No changes detected.[/dim]\n")
+        return
+
+    console.print("\n[bold]Planned Changes:[/bold]\n")
+
+    any_field_changes = False
+    any_resource_changes = False
+    any_creates = False
+
+    for item in changes:
+        change_set = item["change_set"]
+
+        if change_set.change_type == ChangeType.CREATE:
+            any_creates = True
+
+        console.print(f"  {change_set.summary()}")
+
+        if change_set.field_changes:
+            any_field_changes = True
+            console.print(
+                "    [yellow]⚠ Contest field changes (cannot be applied via API):[/yellow]"
+            )
+            for field_change in change_set.field_changes:
+                console.print(f"      • {field_change}")
+
+        for resource_change in change_set.resource_changes:
+            if not resource_change.has_changes:
+                continue
+            any_resource_changes = True
+            console.print(f"    • {resource_change}")
+            if resource_change.to_add and len(resource_change.to_add) <= 10:
+                for item_name in resource_change.to_add:
+                    console.print(f"      + {item_name}")
+            elif resource_change.to_add:
+                console.print(f"      + {len(resource_change.to_add)} items (showing first 10):")
+                for item_name in resource_change.to_add[:10]:
+                    console.print(f"      + {item_name}")
+
+        console.print()
+
+    if any_field_changes:
+        console.print("[yellow]⚠ DOMjudge API Limitation:[/yellow]")
+        console.print("[yellow]  Contest field changes CANNOT be applied via API.[/yellow]")
+        console.print(
+            "[yellow]  → Please update manually in DOMjudge web UI (Jury > Contests)[/yellow]\n"
+        )
+
+    if any_creates or any_resource_changes:
+        console.print("[green]✓ Changes CAN be applied by 'dom contest apply'[/green]\n")
+
+    if not any_field_changes and not any_resource_changes and not any_creates:
+        console.print("[green]✓ All contests are up to date[/green]\n")
+
+
+def render_apply_warnings(results: list[ContestApplyResult]) -> None:
+    """Surface field deltas that could not be applied via the API."""
+    affected = [r for r in results if r.skipped_field_changes]
+    if not affected:
+        return
+
+    for result in affected:
+        changed_fields = ", ".join(fc.field for fc in result.skipped_field_changes)
+        console.print(f"\n[yellow]⚠ Contest '{result.contest_shortname}' already exists[/yellow]")
+        console.print(f"[yellow]  Changed fields detected: {changed_fields}[/yellow]")
+        console.print("[yellow]  → DOMjudge API does not support updating contests[/yellow]")
+        console.print(
+            "[yellow]  → Please update manually in DOMjudge web UI (Jury > Contests)[/yellow]\n"
+        )

--- a/dom/cli/infrastructure/helpers.py
+++ b/dom/cli/infrastructure/helpers.py
@@ -2,9 +2,8 @@
 
 from pathlib import Path
 
-from dom.core.operations import Context, run
+from dom.cli._helpers import load_with_secrets
 from dom.core.operations.infrastructure import load_infra_config_op
-from dom.utils.cli import get_secrets_manager
 
 
 def load_infra_config_with_secrets(file: Path | None, verbose: bool = False):
@@ -12,7 +11,4 @@ def load_infra_config_with_secrets(file: Path | None, verbose: bool = False):
 
     Returns ``(InfraConfig, SecretsManager)``. Raises ``typer.Exit(1)`` on failure.
     """
-    secrets = get_secrets_manager()
-    ctx = Context(secrets=secrets, verbose=verbose)
-    config = run(load_infra_config_op(file), ctx)
-    return config, secrets
+    return load_with_secrets(load_infra_config_op, file, verbose)

--- a/dom/cli/infrastructure/plan.py
+++ b/dom/cli/infrastructure/plan.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import typer
 
 from dom.cli.infrastructure.helpers import load_infra_config_with_secrets
+from dom.cli.infrastructure.render import render_planned_changes
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.infrastructure import plan_infra_changes_op
@@ -26,4 +27,5 @@ def plan_command(
     judges) or require a full restart (e.g., port changes).
     """
     config, secrets = load_infra_config_with_secrets(file, verbose)
-    run(plan_infra_changes_op(config), Context(secrets=secrets, verbose=verbose))
+    change_set = run(plan_infra_changes_op(config), Context(secrets=secrets, verbose=verbose))
+    render_planned_changes(change_set)

--- a/dom/cli/infrastructure/render.py
+++ b/dom/cli/infrastructure/render.py
@@ -1,31 +1,56 @@
-"""Check and display infrastructure status."""
+"""CLI-side renderers for infrastructure output."""
 
 import json
 
 from rich import box
-from rich.console import Console
 from rich.table import Table
 
-from dom.core.operations.framework import Context, operation
-from dom.core.services.infra.service import InfraService
+from dom.core.services.infra.state import InfraChangeSet
+from dom.logging_config import console
 from dom.types.infra import InfrastructureStatus, ServiceStatus
 
 
-@operation("Display infrastructure status", show_progress=False)
-def print_infra_status_op(ctx: Context, json_output: bool = False) -> InfrastructureStatus:
-    status = InfraService(ctx.secrets).check_status()
+def render_planned_changes(change_set: InfraChangeSet | None) -> None:
+    if not change_set:
+        console.print("\n[dim]No infrastructure state found.[/dim]\n")
+        return
+
+    console.print("\n[bold]Planned Infrastructure Changes:[/bold]\n")
+    console.print(f"  {change_set.summary()}\n")
+
+    if change_set.requires_restart:
+        console.print(
+            "  [yellow]⚠ WARNING:[/yellow] This change requires full infrastructure restart"
+        )
+        console.print("  [yellow]⚠ This will cause downtime for running contests![/yellow]\n")
+
+    if change_set.old_config:
+        console.print("  [bold]Current state:[/bold]")
+        console.print(f"    Port:       {change_set.old_config.port}")
+        console.print(f"    Judgehosts: {change_set.old_config.judges}")
+        console.print()
+
+    console.print("  [bold]Desired state:[/bold]")
+    console.print(f"    Port:       {change_set.new_config.port}")
+    console.print(f"    Judgehosts: {change_set.new_config.judges}")
+    console.print()
+
+    if change_set.is_safe_live_change:
+        console.print("  [green]✓ This change is safe to apply to running infrastructure[/green]\n")
+    elif change_set.requires_restart:
+        console.print("  [red]Recommendation:[/red]")
+        console.print("    1. Notify participants of downtime")
+        console.print("    2. Pause or finish active contests")
+        console.print("    3. Run: dom infra destroy --confirm")
+        console.print("    4. Run: dom infra apply")
+        console.print("    5. Reconfigure contests if needed\n")
+
+
+def render_status(status: InfrastructureStatus, *, json_output: bool = False) -> None:
+    """Render infrastructure status to the user."""
     if json_output:
-        _print_status_json(status)
-    else:
-        _print_status_human_readable(status)
-    return status
-
-
-# ---------------------------------------------------------------- presenters
-
-
-def _print_status_human_readable(status: InfrastructureStatus) -> None:
-    console = Console()
+        print(json.dumps(status.to_dict(), indent=2))
+        return
 
     if status.is_healthy():
         console.print("[OK] [bold green]Infrastructure Status: HEALTHY[/bold green]\n")
@@ -81,9 +106,6 @@ def _print_status_human_readable(status: InfrastructureStatus) -> None:
         console.print("\n[OK] [green]Ready to accept commands[/green]")
     else:
         console.print(
-            "\n[**] [yellow]Some services are not healthy. Infrastructure may not be fully operational.[/yellow]"
+            "\n[**] [yellow]Some services are not healthy. "
+            "Infrastructure may not be fully operational.[/yellow]"
         )
-
-
-def _print_status_json(status: InfrastructureStatus) -> None:
-    print(json.dumps(status.to_dict(), indent=2))

--- a/dom/cli/infrastructure/status.py
+++ b/dom/cli/infrastructure/status.py
@@ -4,9 +4,10 @@ from pathlib import Path
 
 import typer
 
+from dom.cli.infrastructure.render import render_status
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
-from dom.core.operations.infrastructure import print_infra_status_op
+from dom.core.operations.infrastructure import check_infra_status_op
 from dom.utils.cli import add_global_options, cli_command, get_secrets_manager
 
 
@@ -32,8 +33,11 @@ def status_command(
     """
     secrets = get_secrets_manager()
     status = run(
-        print_infra_status_op(json_output=json_output),
+        check_infra_status_op(),
         Context(secrets=secrets, verbose=verbose),
     )
-    if status is not None and not status.is_healthy():
+    if status is None:
+        return
+    render_status(status, json_output=json_output)
+    if not status.is_healthy():
         raise typer.Exit(code=1)

--- a/dom/core/config/loaders/problem.py
+++ b/dom/core/config/loaders/problem.py
@@ -25,10 +25,9 @@ logger = get_logger(__name__)
 
 
 def convert_and_load_problem(archive_path: Path, with_statement: bool) -> ProblemPackage:
-    """
-    Convert a Polygon archive to a DOMjudge package and load it (no caching).
-    """
-    assert archive_path.exists(), f"Archive not found: {archive_path}"
+    """Convert a Polygon archive to a DOMjudge package and load it (no caching)."""
+    if not archive_path.exists():
+        raise FileNotFoundError(f"Archive not found: {archive_path}")
 
     # Always convert into a fresh temporary ZIP
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/dom/core/operations/contest/apply.py
+++ b/dom/core/operations/contest/apply.py
@@ -1,37 +1,39 @@
 """Apply contest configuration to the DOMjudge platform."""
 
-from dom.core.operations.framework import Context, Step, Steps, operation
+from dom.core.operations.framework import Context, operation
 from dom.core.operations.wiring import wire_admin_api
-from dom.core.services.contest.apply import ContestApplicationService
+from dom.core.services.contest.apply import ContestApplicationService, ContestApplyResult
+from dom.core.services.contest.state import ContestStateComparator
+from dom.core.services.problem.apply import ProblemService
+from dom.core.services.team.apply import TeamService
 from dom.types.config.processed import DomConfig
 
 
-def _summary(config: DomConfig) -> str:
-    if len(config.contests) == 1:
-        c = config.contests[0]
-        return f"Applied '{c.shortname}' • {len(c.problems)} problems • {len(c.teams)} teams"
-    details = [f"{c.shortname}: {len(c.problems)}p/{len(c.teams)}t" for c in config.contests]
-    return f"Applied {len(config.contests)} contests ({', '.join(details)})"
+def _summary(results: list[ContestApplyResult]) -> str:
+    if len(results) == 1:
+        r = results[0]
+        suffix = " (with skipped field changes)" if r.skipped_field_changes else ""
+        return f"Applied '{r.contest_shortname}'{suffix}"
+    skipped = sum(1 for r in results if r.skipped_field_changes)
+    suffix = f" • {skipped} with skipped field changes" if skipped else ""
+    return f"Applied {len(results)} contests{suffix}"
 
 
-def _apply_all(config: DomConfig, ctx: Context) -> None:
-    """Wire an admin API client and push every contest through the service."""
+def _apply_all(config: DomConfig, ctx: Context) -> list[ContestApplyResult]:
+    """Wire dependencies once, then apply every contest through the service."""
     client = wire_admin_api(config.infra, ctx.secrets)
-    service = ContestApplicationService(client, ctx.secrets)
-    for contest in config.contests:
-        service.apply_contest(contest)
+    service = ContestApplicationService(
+        client,
+        ctx.secrets,
+        problem_service=ProblemService(client),
+        team_service=TeamService(client),
+        state_comparator=ContestStateComparator(client),
+    )
+    return [service.apply_contest(contest) for contest in config.contests]
 
 
-@operation("Apply contests")
-def apply_contests_op(ctx: Context, config: DomConfig) -> Steps:
+@operation("Apply contests", summary=_summary, show_progress=False)
+def apply_contests_op(ctx: Context, config: DomConfig) -> list[ContestApplyResult]:
     if not config.contests:
         raise ValueError("No contests in configuration")
-    return Steps(
-        steps=[
-            Step(
-                f"Push {len(config.contests)} contest(s) to platform",
-                lambda: _apply_all(config, ctx),
-            ),
-        ],
-        summary=_summary(config),
-    )
+    return _apply_all(config, ctx)

--- a/dom/core/operations/contest/plan_changes.py
+++ b/dom/core/operations/contest/plan_changes.py
@@ -4,9 +4,7 @@ from typing import Any
 
 from dom.core.operations.framework import Context, operation
 from dom.core.operations.wiring import wire_admin_api
-from dom.core.services.contest.changes import ChangeType
 from dom.core.services.contest.state import ContestStateComparator
-from dom.logging_config import console
 from dom.types.config.processed import DomConfig
 
 
@@ -17,70 +15,10 @@ def _summary(changes: list[dict[str, Any]]) -> str:
 
 @operation("Plan contest changes", summary=_summary, show_progress=False)
 def plan_contest_changes_op(ctx: Context, config: DomConfig) -> list[dict[str, Any]]:
+    """Compute per-contest change sets. Rendering is the CLI's job."""
     client = wire_admin_api(config.infra, ctx.secrets)
     comparator = ContestStateComparator(client)
-    changes = [
+    return [
         {"shortname": contest.shortname, "change_set": comparator.compare_contest(contest)}
         for contest in config.contests
     ]
-    _print_planned_changes(changes)
-    return changes
-
-
-# ---------------------------------------------------------------- presenter
-
-
-def _print_planned_changes(changes: list[dict[str, Any]]) -> None:
-    if not changes:
-        console.print("\n[dim]No changes detected.[/dim]\n")
-        return
-
-    console.print("\n[bold]Planned Changes:[/bold]\n")
-
-    any_field_changes = False
-    any_resource_changes = False
-    any_creates = False
-
-    for item in changes:
-        change_set = item["change_set"]
-
-        if change_set.change_type == ChangeType.CREATE:
-            any_creates = True
-
-        console.print(f"  {change_set.summary()}")
-
-        if change_set.field_changes:
-            any_field_changes = True
-            console.print(
-                "    [yellow]⚠ Contest field changes (cannot be applied via API):[/yellow]"
-            )
-            for field_change in change_set.field_changes:
-                console.print(f"      • {field_change}")
-
-        for resource_change in change_set.resource_changes:
-            if not resource_change.has_changes:
-                continue
-            any_resource_changes = True
-            console.print(f"    • {resource_change}")
-            if resource_change.to_add and len(resource_change.to_add) <= 10:
-                for item_name in resource_change.to_add:
-                    console.print(f"      + {item_name}")
-            elif resource_change.to_add:
-                console.print(f"      + {len(resource_change.to_add)} items (showing first 10):")
-                for item_name in resource_change.to_add[:10]:
-                    console.print(f"      + {item_name}")
-
-        console.print()
-
-    if any_field_changes:
-        console.print("[yellow]⚠ DOMjudge API Limitation:[/yellow]")
-        console.print("[yellow]  Contest field changes CANNOT be applied via API.[/yellow]")
-        console.print(
-            "[yellow]  → Please update manually in DOMjudge web UI (Jury > Contests)[/yellow]\n"
-        )
-
-    if any_creates or any_resource_changes:
-        console.print("[green]✓ Changes CAN be applied by 'dom contest apply'[/green]\n")
-
-    if not any_field_changes and not any_resource_changes and not any_creates:
-        console.print("[green]✓ All contests are up to date[/green]\n")

--- a/dom/core/operations/infrastructure/__init__.py
+++ b/dom/core/operations/infrastructure/__init__.py
@@ -5,7 +5,6 @@ from .check_status import check_infra_status_op
 from .destroy import destroy_infrastructure_op
 from .load_config import load_infra_config_op
 from .plan_changes import plan_infra_changes_op
-from .print_status import print_infra_status_op
 
 __all__ = [
     "apply_infrastructure_op",
@@ -13,5 +12,4 @@ __all__ = [
     "destroy_infrastructure_op",
     "load_infra_config_op",
     "plan_infra_changes_op",
-    "print_infra_status_op",
 ]

--- a/dom/core/operations/infrastructure/plan_changes.py
+++ b/dom/core/operations/infrastructure/plan_changes.py
@@ -2,7 +2,6 @@
 
 from dom.core.operations.framework import Context, operation
 from dom.core.services.infra.state import InfraChangeSet, InfraStateComparator
-from dom.logging_config import console
 from dom.types.infra import InfraConfig
 
 
@@ -15,45 +14,5 @@ def _summary(change_set: InfraChangeSet | None) -> str:
 
 @operation("Plan infrastructure changes", summary=_summary, show_progress=False)
 def plan_infra_changes_op(_ctx: Context, config: InfraConfig) -> InfraChangeSet | None:
-    change_set = InfraStateComparator().compare_infrastructure(config)
-    _print_planned_changes(change_set)
-    return change_set
-
-
-# ---------------------------------------------------------------- presenter
-
-
-def _print_planned_changes(change_set: InfraChangeSet | None) -> None:
-    if not change_set:
-        console.print("\n[dim]No infrastructure state found.[/dim]\n")
-        return
-
-    console.print("\n[bold]Planned Infrastructure Changes:[/bold]\n")
-    console.print(f"  {change_set.summary()}\n")
-
-    if change_set.requires_restart:
-        console.print(
-            "  [yellow]⚠ WARNING:[/yellow] This change requires full infrastructure restart"
-        )
-        console.print("  [yellow]⚠ This will cause downtime for running contests![/yellow]\n")
-
-    if change_set.old_config:
-        console.print("  [bold]Current state:[/bold]")
-        console.print(f"    Port:       {change_set.old_config.port}")
-        console.print(f"    Judgehosts: {change_set.old_config.judges}")
-        console.print()
-
-    console.print("  [bold]Desired state:[/bold]")
-    console.print(f"    Port:       {change_set.new_config.port}")
-    console.print(f"    Judgehosts: {change_set.new_config.judges}")
-    console.print()
-
-    if change_set.is_safe_live_change:
-        console.print("  [green]✓ This change is safe to apply to running infrastructure[/green]\n")
-    elif change_set.requires_restart:
-        console.print("  [red]Recommendation:[/red]")
-        console.print("    1. Notify participants of downtime")
-        console.print("    2. Pause or finish active contests")
-        console.print("    3. Run: dom infra destroy --confirm")
-        console.print("    4. Run: dom infra apply")
-        console.print("    5. Reconfigure contests if needed\n")
+    """Compute the infrastructure change set. Rendering is the CLI's job."""
+    return InfraStateComparator().compare_infrastructure(config)

--- a/dom/core/services/base.py
+++ b/dom/core/services/base.py
@@ -106,50 +106,16 @@ class Service(ABC, Generic[TEntity]):
 
 
 class BulkOperationMixin(Generic[TEntity]):
+    """Aggregation helpers for services that operate on many entities at once.
+
+    Concrete services (``ProblemService``, ``TeamService``) implement
+    their own concurrent ``create_many`` and use this mixin only for
+    summarizing the resulting list.
     """
-    Mixin for services that support bulk operations.
 
-    Provides declarative methods for operating on multiple entities at once.
-    """
-
-    def create_many(
-        self,
-        entities: list[TEntity],
-        context: ServiceContext,
-        stop_on_error: bool = False,
-    ) -> list[ServiceResult[TEntity]]:
-        """
-        Create multiple entities.
-
-        Args:
-            entities: List of entities to create
-            context: Service context
-            stop_on_error: Stop on first error if True
-
-        Returns:
-            List of service results
-        """
-        results: list[ServiceResult[TEntity]] = []
-
-        for entity in entities:
-            result = self.create(entity, context)  # type: ignore[attr-defined]
-            results.append(result)
-
-            if stop_on_error and not result.success:
-                break
-
-        return results
-
-    def get_summary(self, results: list[ServiceResult[TEntity]]) -> dict[str, int]:
-        """
-        Get summary of operation results.
-
-        Args:
-            results: List of service results
-
-        Returns:
-            Summary with success/failure counts
-        """
+    @staticmethod
+    def get_summary(results: list[ServiceResult[TEntity]]) -> dict[str, int]:
+        """Counts of total / successful / failed / created entities."""
         return {
             "total": len(results),
             "successful": sum(1 for r in results if r.success),

--- a/dom/core/services/contest/apply.py
+++ b/dom/core/services/contest/apply.py
@@ -1,15 +1,22 @@
-"""Declarative contest application service."""
+"""Declarative contest application service.
 
+The orchestrator (:meth:`ContestApplicationService.apply_contest`) reads
+top-down as a sequence of named steps. Each step is implemented as a
+small, single-purpose private method below the orchestrator.
+"""
+
+from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
 
 from dom.core.services.base import ServiceContext
-from dom.core.services.contest.changes import ChangeType
+from dom.core.services.contest.changes import ChangeType, ContestChangeSet, FieldChange
 from dom.core.services.contest.state import ContestStateComparator
 from dom.core.services.problem.apply import ProblemService
 from dom.core.services.protocols import DomJudgeAPIProtocol
 from dom.core.services.team.apply import TeamService
 from dom.exceptions import ContestError
-from dom.logging_config import console, get_logger
+from dom.logging_config import get_logger
 from dom.types.api.models import Contest
 from dom.types.config.processed import ContestConfig
 from dom.types.secrets import SecretsProvider
@@ -17,227 +24,236 @@ from dom.types.secrets import SecretsProvider
 logger = get_logger(__name__)
 
 
+@dataclass(frozen=True)
+class ContestApplyResult:
+    """Outcome of applying a single contest.
+
+    ``skipped_field_changes`` lists field deltas that were detected on an
+    existing contest but could not be applied (DOMjudge API does not
+    support contest updates). The CLI layer renders these to the user;
+    the service stays free of presentation concerns.
+    """
+
+    contest_shortname: str
+    contest_id: str
+    skipped_field_changes: list[FieldChange] = field(default_factory=list)
+
+
 class ContestApplicationService:
+    """Declarative service for applying contest configurations.
+
+    Idempotent and intended for INITIAL SETUP only. The DOMjudge API
+    does not support contest updates: if a contest already exists with
+    different fields, the deltas are surfaced via
+    :class:`ContestApplyResult.skipped_field_changes` rather than applied.
+    Resources (problems, teams) are always reconciled idempotently.
     """
-    Declarative service for applying contest configurations.
 
-    This service orchestrates the creation of contests and their associated
-    resources (problems, teams) in a clean, declarative manner.
-    """
-
-    def __init__(self, client: DomJudgeAPIProtocol, secrets: SecretsProvider):
-        """
-        Initialize contest application service.
-
-        Args:
-            client: DOMjudge API client
-            secrets: Secrets manager
-        """
+    def __init__(
+        self,
+        client: DomJudgeAPIProtocol,
+        secrets: SecretsProvider,
+        *,
+        problem_service: ProblemService | None = None,
+        team_service: TeamService | None = None,
+        state_comparator: ContestStateComparator | None = None,
+    ):
         self.client = client
         self.secrets = secrets
-        self.problem_service = ProblemService(client)
-        self.team_service = TeamService(client)
-        self.state_comparator = ContestStateComparator(client)
+        self.problem_service = problem_service or ProblemService(client)
+        self.team_service = team_service or TeamService(client)
+        self.state_comparator = state_comparator or ContestStateComparator(client)
 
-    def apply_contest(self, contest: ContestConfig) -> str:
+    # ------------------------------------------------------------------ public
+
+    def apply_contest(self, contest: ContestConfig) -> ContestApplyResult:
+        """Apply a single contest configuration.
+
+        Reads top-down as a sequence of steps:
+        compare → create-or-resolve → provision team group → apply resources.
         """
-        Apply a single contest configuration.
-
-        This method is idempotent and safe for INITIAL SETUP only:
-        - If contest doesn't exist, creates it
-        - If contest exists, SKIPS contest fields (cannot be updated via API)
-        - Resources (problems/teams) are always applied idempotently
-
-        IMPORTANT: DOMjudge API does NOT support updating contests.
-        This tool is designed for INITIAL SETUP only. Once contests are created,
-        any changes to contest fields must be made manually via the DOMjudge web UI.
-
-        Args:
-            contest: Contest configuration
-
-        Returns:
-            Contest ID
-
-        Raises:
-            ContestError: If contest application fails
-        """
+        shortname = _require_shortname(contest)
         logger.info(
             "Applying contest configuration",
-            extra={
-                "contest_name": contest.name,
-                "contest_shortname": contest.shortname,
-            },
+            extra={"contest_name": contest.name, "contest_shortname": shortname},
         )
 
-        # Detect changes first
         change_set = self.state_comparator.compare_contest(contest)
+        contest_id, skipped = self._resolve_or_create(contest, change_set)
+        team_group_id = self._provision_team_group(contest_id, shortname)
 
-        # Create or skip contest
-        if change_set.change_type == ChangeType.CREATE:
-            contest_id = self._create_contest(contest)
-            logger.info(f"✓ Created new contest '{contest.shortname}' (ID: {contest_id})")
-        else:
-            # Get existing contest
-            assert contest.shortname is not None, "Contest shortname is required"
-            current = self.state_comparator._fetch_current_contest(contest.shortname)
-            assert current is not None, f"Contest '{contest.shortname}' should exist at this point"
-            contest_id = current["id"]
-
-            # Show warning if there are field changes
-            if change_set.field_changes:
-                changed_fields = ", ".join([fc.field for fc in change_set.field_changes])
-                console.print(f"\n[yellow]⚠ Contest '{contest.shortname}' already exists[/yellow]")
-                console.print(f"[yellow]  Changed fields detected: {changed_fields}[/yellow]")
-                console.print(
-                    "[yellow]  → DOMjudge API does not support updating contests[/yellow]"
-                )
-                console.print(
-                    "[yellow]  → Please update manually in DOMjudge web UI (Jury > Contests)[/yellow]\n"
-                )
-
-                logger.warning(
-                    f"Contest '{contest.shortname}' exists with field changes that cannot be applied via API",
-                    extra={
-                        "contest_id": contest_id,
-                        "changed_fields": changed_fields,
-                    },
-                )
-            else:
-                logger.info(f"✓ Contest '{contest.shortname}' exists with no field changes")
-
-        # Create contest-specific team group for scoreboard filtering
-        shortname = contest.shortname or "contest"
-        group_name = f"{shortname.upper()} Teams"
-        group_result = self.client.groups.create_for_contest(
-            contest_id=contest_id, name=group_name, group_id=f"{shortname}-teams"
+        self._apply_resources(
+            contest,
+            ServiceContext(
+                client=self.client,
+                contest_id=contest_id,
+                contest_shortname=shortname,
+                team_group_id=team_group_id,
+            ),
         )
-        team_group_id = group_result.id
 
         logger.info(
-            f"Created team group '{group_name}' (ID: {team_group_id}) for contest {contest.shortname}"
-        )
-
-        # Create service context for this contest with the group
-        context = ServiceContext(
-            client=self.client,
-            contest_id=contest_id,
-            contest_shortname=contest.shortname,
-            team_group_id=team_group_id,
-        )
-
-        # Apply resources concurrently
-        self._apply_contest_resources(contest, context)
-
-        logger.info(
-            f"Successfully configured contest '{contest.shortname}'",
+            f"Successfully configured contest '{shortname}'",
             extra={
                 "contest_id": contest_id,
-                "contest_shortname": contest.shortname,
+                "contest_shortname": shortname,
                 "problems_count": len(contest.problems),
                 "teams_count": len(contest.teams),
             },
         )
+        return ContestApplyResult(
+            contest_shortname=shortname,
+            contest_id=contest_id,
+            skipped_field_changes=skipped,
+        )
 
-        return contest_id
+    # ------------------------------------------------------------------ steps
+
+    def _resolve_or_create(
+        self, contest: ContestConfig, change_set: ContestChangeSet
+    ) -> tuple[str, list[FieldChange]]:
+        """Return ``(contest_id, skipped_field_changes)`` for the contest.
+
+        Creates a new contest when the change set says so; otherwise
+        resolves the existing one and reports any field deltas that
+        cannot be applied via the API.
+        """
+        shortname = change_set.contest_shortname
+
+        if change_set.change_type == ChangeType.CREATE:
+            contest_id = self._create_contest(contest)
+            logger.info(f"✓ Created new contest '{shortname}' (ID: {contest_id})")
+            return contest_id, []
+
+        contest_id = self._resolve_existing_contest_id(shortname)
+
+        if not change_set.field_changes:
+            logger.info(f"✓ Contest '{shortname}' exists with no field changes")
+            return contest_id, []
+
+        skipped = list(change_set.field_changes)
+        logger.warning(
+            f"Contest '{shortname}' exists with field changes that cannot be applied via API",
+            extra={
+                "contest_id": contest_id,
+                "changed_fields": ", ".join(fc.field for fc in skipped),
+            },
+        )
+        return contest_id, skipped
+
+    def _resolve_existing_contest_id(self, shortname: str) -> str:
+        current = self.state_comparator._fetch_current_contest(shortname)
+        if current is None:
+            raise ContestError(
+                f"Contest '{shortname}' was expected to exist but could not be fetched"
+            )
+        return str(current["id"])
 
     def _create_contest(self, contest: ContestConfig) -> str:
-        """
-        Create or get contest.
-
-        Args:
-            contest: Contest configuration
-
-        Returns:
-            Contest ID
-        """
+        shortname = _require_shortname(contest)
         try:
             result = self.client.contests.create(
                 contest_data=Contest(
-                    name=contest.name or contest.shortname,  # type: ignore[arg-type]
-                    shortname=contest.shortname,  # type: ignore[arg-type]
+                    name=contest.name or shortname,
+                    shortname=shortname,
                     formal_name=contest.formal_name or contest.name,
                     start_time=contest.start_time,
                     duration=contest.duration,
                     allow_submit=contest.allow_submit,
                 )
             )
-
-            action = "Created" if result.created else "Found existing"
-            logger.info(
-                f"{action} contest",
-                extra={
-                    "contest_id": result.id,
-                    "contest_shortname": contest.shortname,
-                    "was_created": result.created,
-                },
-            )
-
-            return str(result.id)
-
-        except Exception as e:
+        except Exception as exc:
             logger.error(
-                f"Failed to create/get contest '{contest.shortname}'",
+                f"Failed to create/get contest '{shortname}'",
                 exc_info=True,
-                extra={"contest_shortname": contest.shortname},
+                extra={"contest_shortname": shortname},
             )
-            raise ContestError(f"Failed to create/get contest '{contest.shortname}': {e}") from e
+            raise ContestError(f"Failed to create/get contest '{shortname}': {exc}") from exc
 
-    def _apply_contest_resources(self, contest: ContestConfig, context: ServiceContext) -> None:
-        """
-        Apply problems and teams to contest concurrently.
+        action = "Created" if result.created else "Found existing"
+        logger.info(
+            f"{action} contest",
+            extra={
+                "contest_id": result.id,
+                "contest_shortname": shortname,
+                "was_created": result.created,
+            },
+        )
+        return str(result.id)
 
-        Args:
-            contest: Contest configuration
-            context: Service context
+    def _provision_team_group(self, contest_id: str, shortname: str) -> str:
+        """Create the contest-specific team group used for scoreboard filtering."""
+        group_name = f"{shortname.upper()} Teams"
+        result = self.client.groups.create_for_contest(
+            contest_id=contest_id, name=group_name, group_id=f"{shortname}-teams"
+        )
+        logger.info(f"Created team group '{group_name}' (ID: {result.id}) for contest {shortname}")
+        return str(result.id)
 
-        Raises:
-            ContestError: If resource application fails
-        """
-        exceptions = []
-
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            # Submit concurrent tasks
-            future_to_task = {
-                executor.submit(self._apply_problems, contest.problems, context): "problems",
-                executor.submit(self._apply_teams, contest.teams, context): "teams",
-            }
-
-            # Collect results
-            for future in as_completed(future_to_task.keys()):
-                task_name = future_to_task[future]
-                try:
-                    future.result()
-                    logger.info(f"Successfully applied {task_name} for contest {contest.shortname}")
-                except Exception as e:
-                    logger.error(
-                        f"Failed to apply {task_name} for contest {contest.shortname}",
-                        exc_info=True,
-                        extra={
-                            "task": task_name,
-                            "contest_shortname": contest.shortname,
-                            "contest_id": context.contest_id,
-                        },
-                    )
-                    exceptions.append((task_name, e))
-
-        if exceptions:
-            error_details = ", ".join([f"{task}: {e!s}" for task, e in exceptions])
+    def _apply_resources(self, contest: ContestConfig, context: ServiceContext) -> None:
+        """Apply problems and teams concurrently, collecting any failures."""
+        tasks: dict[str, Callable[[], None]] = {
+            "problems": lambda: self._apply_problems(contest.problems, context),
+            "teams": lambda: self._apply_teams(contest.teams, context),
+        }
+        failures = _run_concurrent(tasks, context, contest.shortname or "?")
+        if failures:
+            details = ", ".join(f"{name}: {exc!s}" for name, exc in failures)
             raise ContestError(
-                f"Failed to fully configure contest '{contest.shortname}': {error_details}"
+                f"Failed to fully configure contest '{contest.shortname}': {details}"
             )
 
     def _apply_problems(self, problems, context: ServiceContext) -> None:
-        """Apply problems using problem service."""
         results = self.problem_service.create_many(problems, context, stop_on_error=False)
-
         summary = self.problem_service.get_summary(results)
         if summary["failed"] > 0:
             raise ContestError(f"{summary['failed']} problem(s) failed to add")
 
     def _apply_teams(self, teams, context: ServiceContext) -> None:
-        """Apply teams using team service."""
         results = self.team_service.create_many(teams, context, stop_on_error=False)
-
         summary = self.team_service.get_summary(results)
         if summary["failed"] > 0:
             raise ContestError(f"{summary['failed']} team(s) failed to add")
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _require_shortname(contest: ContestConfig) -> str:
+    """Treat shortname as a precondition. Loaders must guarantee it."""
+    if contest.shortname is None:
+        raise ContestError("Contest configuration is missing required 'shortname'")
+    return contest.shortname
+
+
+def _run_concurrent(
+    tasks: dict[str, Callable[[], None]],
+    context: ServiceContext,
+    contest_shortname: str,
+) -> list[tuple[str, Exception]]:
+    """Run named tasks in parallel, returning ``(name, exc)`` for each failure.
+
+    All tasks run to completion even if some fail, so the caller sees
+    every problem at once instead of fixing them one round-trip at a time.
+    """
+    failures: list[tuple[str, Exception]] = []
+    with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
+        futures = {executor.submit(fn): name for name, fn in tasks.items()}
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                future.result()
+            except Exception as exc:
+                logger.error(
+                    f"Failed to apply {name} for contest {contest_shortname}",
+                    exc_info=True,
+                    extra={
+                        "task": name,
+                        "contest_shortname": contest_shortname,
+                        "contest_id": context.contest_id,
+                    },
+                )
+                failures.append((name, exc))
+            else:
+                logger.info(f"Successfully applied {name} for contest {contest_shortname}")
+    return failures

--- a/dom/core/services/contest/state.py
+++ b/dom/core/services/contest/state.py
@@ -1,5 +1,16 @@
-"""Contest state comparison and change detection service."""
+"""Contest state comparison and change detection service.
 
+The comparator is structured around three declarative pieces:
+
+* :data:`_FIELD_SPECS` — the list of contest fields to diff, each with
+  its own value extractors and (optional) normalizer.
+* :func:`_diff_resource` — a generic "compare desired vs current by key"
+  helper used for problems and teams.
+* :class:`ContestStateComparator` — wires the API client into the above.
+"""
+
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
 from typing import Any
 
 from dom.core.services.contest.changes import (
@@ -9,6 +20,7 @@ from dom.core.services.contest.changes import (
     ResourceChange,
 )
 from dom.core.services.protocols import DomJudgeAPIProtocol
+from dom.exceptions import APIError, ContestError
 from dom.logging_config import get_logger
 from dom.types.config.processed import ContestConfig
 from dom.utils.cli import get_secrets_manager
@@ -16,288 +28,229 @@ from dom.utils.hashing import generate_team_username
 
 logger = get_logger(__name__)
 
+# ---------------------------------------------------------------- field specs
+
+
+@dataclass(frozen=True)
+class _FieldSpec:
+    """How to read and compare one contest field."""
+
+    name: str
+    extract_desired: Callable[[ContestConfig], Any]
+    extract_current: Callable[[dict[str, Any]], Any]
+    normalize: Callable[[Any], Any] = lambda v: None if v is None else str(v)
+
+
+def _normalize_duration(value: Any) -> str:
+    """Pad ``H:MM:SS[.ms]`` to ``HH:MM:SS.mmm`` so format variations compare equal."""
+    if not value:
+        return ""
+    duration = str(value)
+    try:
+        time_part, ms_part = duration.split(".") if "." in duration else (duration, "000")
+        parts = time_part.split(":")
+        if len(parts) != 3:
+            return duration
+        h, m, s = parts
+        return f"{int(h):02d}:{int(m):02d}:{int(s):02d}.{ms_part}"
+    except (ValueError, AttributeError):
+        return duration
+
+
+_FIELD_SPECS: tuple[_FieldSpec, ...] = (
+    _FieldSpec(
+        name="name",
+        extract_desired=lambda d: d.name or d.shortname,
+        extract_current=lambda c: c.get("name"),
+    ),
+    _FieldSpec(
+        name="formal_name",
+        extract_desired=lambda d: d.formal_name or d.name,
+        extract_current=lambda c: c.get("formal_name"),
+    ),
+    _FieldSpec(
+        name="duration",
+        extract_desired=lambda d: d.duration,
+        extract_current=lambda c: c.get("duration"),
+        normalize=_normalize_duration,
+    ),
+    _FieldSpec(
+        name="allow_submit",
+        extract_desired=lambda d: d.allow_submit,
+        extract_current=lambda c: c.get("allow_submit"),
+    ),
+    _FieldSpec(
+        name="penalty_time",
+        extract_desired=lambda d: d.penalty_time,
+        extract_current=lambda c: c.get("penalty_time"),
+    ),
+)
+
+
+# ---------------------------------------------------------------- generic diff
+
+
+@dataclass(frozen=True)
+class _Diff:
+    to_add: list[str]
+    unchanged: list[str]
+
+
+def _diff_resource(
+    desired_keys: Iterable[str],
+    current_keys: Iterable[str],
+    *,
+    display: dict[str, str] | None = None,
+) -> _Diff:
+    """Set-diff two key collections, optionally projecting back to display names."""
+    desired_set = set(desired_keys)
+    current_set = set(current_keys)
+    project = (lambda k: display[k]) if display else (lambda k: k)
+    return _Diff(
+        to_add=[project(k) for k in desired_set - current_set],
+        unchanged=[project(k) for k in desired_set & current_set],
+    )
+
+
+# ---------------------------------------------------------------- comparator
+
 
 class ContestStateComparator:
-    """
-    Service for comparing desired contest state with current state.
+    """Compare desired contest state with the live state from the API.
 
-    This service enables safe live changes by detecting exactly what changed
-    between the current state and desired configuration.
+    Used by both ``plan`` (to preview changes) and ``apply`` (to decide
+    create-vs-skip per contest).
     """
 
     def __init__(self, client: DomJudgeAPIProtocol):
-        """
-        Initialize state comparator.
-
-        Args:
-            client: DOMjudge API client
-        """
         self.client = client
 
     def compare_contest(
         self, desired: ContestConfig, current: dict[str, Any] | None = None
     ) -> ContestChangeSet:
-        """
-        Compare desired contest configuration with current state.
-
-        Args:
-            desired: Desired contest configuration
-            current: Current contest state from API (if None, will fetch)
-
-        Returns:
-            ContestChangeSet describing all changes
-        """
-        # shortname is required for state comparison
-        assert desired.shortname is not None, "Contest shortname is required for state comparison"
-
-        # Fetch current state if not provided
+        shortname = _require_shortname(desired)
         if current is None:
-            current = self._fetch_current_contest(desired.shortname)
+            current = self._fetch_current_contest(shortname)
 
-        # Determine change type
         if current is None:
             return ContestChangeSet(
-                contest_shortname=desired.shortname,
+                contest_shortname=shortname,
                 change_type=ChangeType.CREATE,
                 field_changes=[],
                 resource_changes=[],
             )
 
-        # Compare fields
-        field_changes = self._compare_contest_fields(desired, current)
-
-        # Compare resources (problems and teams)
+        field_changes = self._diff_fields(desired, current)
         contest_id = current["id"]
-        problem_changes = self._compare_problems(desired, contest_id)
-        team_changes = self._compare_teams(desired, contest_id)
-
-        change_type = ChangeType.UPDATE if field_changes else ChangeType.NO_CHANGE
-
         return ContestChangeSet(
-            contest_shortname=desired.shortname,
-            change_type=change_type,
+            contest_shortname=shortname,
+            change_type=ChangeType.UPDATE if field_changes else ChangeType.NO_CHANGE,
             field_changes=field_changes,
-            resource_changes=[problem_changes, team_changes],
+            resource_changes=[
+                self._diff_problems(desired, contest_id),
+                self._diff_teams(desired, contest_id),
+            ],
         )
 
+    # ------------------------------------------------------------------ fetch
+
     def _fetch_current_contest(self, shortname: str) -> dict[str, Any] | None:
-        """
-        Fetch current contest from API by shortname.
-
-        Args:
-            shortname: Contest shortname
-
-        Returns:
-            Contest data or None if not found
-        """
         try:
-            contests = self.client.contests.list_all()
-            for contest in contests:
+            for contest in self.client.contests.list_all():
                 if contest.get("shortname") == shortname:
                     logger.debug(f"Found existing contest '{shortname}'")
                     return contest
-            logger.debug(f"Contest '{shortname}' not found (will be created)")
-            return None
-        except Exception as e:
+        except APIError as e:
             logger.warning(f"Failed to fetch contest '{shortname}': {e}")
             return None
+        logger.debug(f"Contest '{shortname}' not found (will be created)")
+        return None
 
-    def _compare_contest_fields(
-        self, desired: ContestConfig, current: dict[str, Any]
-    ) -> list[FieldChange]:
-        """
-        Compare contest fields to detect changes.
+    # ------------------------------------------------------------------ fields
 
-        Args:
-            desired: Desired configuration
-            current: Current state
-
-        Returns:
-            List of field changes
-        """
-        changes = []
-
-        # Map of field names to compare
-        fields_to_compare = {
-            "name": (desired.name or desired.shortname, current.get("name")),
-            "formal_name": (
-                desired.formal_name or desired.name,
-                current.get("formal_name"),
-            ),
-            "duration": (desired.duration, current.get("duration")),
-            "allow_submit": (desired.allow_submit, current.get("allow_submit")),
-            "penalty_time": (desired.penalty_time, current.get("penalty_time")),
-        }
-
-        for field, (new_val, old_val) in fields_to_compare.items():
+    def _diff_fields(self, desired: ContestConfig, current: dict[str, Any]) -> list[FieldChange]:
+        """Walk the field specs and emit a FieldChange per detected delta."""
+        changes: list[FieldChange] = []
+        for spec in _FIELD_SPECS:
+            new_val = spec.extract_desired(desired)
             if new_val is None:
                 continue
-
-            # Normalize values for comparison
-            if field == "duration":
-                # Normalize duration format (handle leading zeros)
-                normalized_new = self._normalize_duration(str(new_val))
-                normalized_old = self._normalize_duration(str(old_val) if old_val else "")
-                if normalized_new != normalized_old:
-                    changes.append(FieldChange(field=field, old_value=old_val, new_value=new_val))
-                    logger.debug(f"Field change detected: {field} ({old_val} → {new_val})")
-            elif str(new_val) != str(old_val):
-                changes.append(FieldChange(field=field, old_value=old_val, new_value=new_val))
-                logger.debug(f"Field change detected: {field} ({old_val} → {new_val})")
-
+            old_val = spec.extract_current(current)
+            if spec.normalize(new_val) != spec.normalize(old_val):
+                logger.debug(f"Field change detected: {spec.name} ({old_val} → {new_val})")
+                changes.append(FieldChange(field=spec.name, old_value=old_val, new_value=new_val))
         return changes
 
-    def _normalize_duration(self, duration: str) -> str:
-        """
-        Normalize duration format for comparison.
+    # ------------------------------------------------------------------ resources
 
-        Converts formats like:
-        - "5:00:00.000" -> "05:00:00.000"
-        - "05:00:00.000" -> "05:00:00.000"
-        - "1:30:00" -> "01:30:00.000"
-
-        Args:
-            duration: Duration string
-
-        Returns:
-            Normalized duration string
-        """
-        if not duration:
-            return ""
-
+    def _diff_problems(self, desired: ContestConfig, contest_id: str) -> ResourceChange:
+        desired_ids = [p.ini.externalid for p in desired.problems if p.ini and p.ini.externalid]
         try:
-            # Split into time and milliseconds
-            if "." in duration:
-                time_part, ms_part = duration.split(".")
-            else:
-                time_part, ms_part = duration, "000"
-
-            # Split time into components
-            parts = time_part.split(":")
-
-            if len(parts) == 3:
-                hours, minutes, seconds = parts
-                # Pad each component to 2 digits
-                normalized = f"{int(hours):02d}:{int(minutes):02d}:{int(seconds):02d}.{ms_part}"
-                return normalized
-
-            # If format is unexpected, return as-is
-            return duration
-        except (ValueError, AttributeError):
-            # If parsing fails, return as-is
-            return duration
-
-    def _compare_problems(self, desired: ContestConfig, contest_id: str) -> ResourceChange:
-        """
-        Compare problems to detect additions.
-
-        Args:
-            desired: Desired configuration
-            contest_id: Contest ID
-
-        Returns:
-            ResourceChange for problems
-        """
-        try:
-            # Get current problems in contest
-            current_problems = self.client.problems.list_for_contest(contest_id)
-            current_problem_ids = {p.get("externalid") or p.get("id") for p in current_problems}
-
-            # Get desired problems - ProblemPackage stores externalid in ini.externalid
-            desired_problem_ids = {
-                p.ini.externalid for p in desired.problems if p.ini and p.ini.externalid
-            }
-
-            # Calculate changes
-            to_add = list(desired_problem_ids - current_problem_ids)
-            unchanged = list(desired_problem_ids & current_problem_ids)
-
-            logger.debug(f"Problem comparison: {len(to_add)} to add, {len(unchanged)} unchanged")
-
-            return ResourceChange(
-                resource_type="problems",
-                to_add=to_add,
-                to_remove=[],  # Not implemented yet
-                unchanged=unchanged,
-            )
-        except Exception as e:
+            current = self.client.problems.list_for_contest(contest_id)
+        except APIError as e:
             logger.warning(f"Failed to compare problems: {e}", exc_info=True)
-            # On error, assume all need to be added (idempotent operation will handle)
-            desired_ids = []
-            for p in desired.problems:
-                if p.ini and hasattr(p.ini, "externalid") and p.ini.externalid:
-                    desired_ids.append(p.ini.externalid)
+            # Fall back to assuming everything is new; the apply path is idempotent.
             return ResourceChange(
-                resource_type="problems",
-                to_add=desired_ids,
-                to_remove=[],
-                unchanged=[],
+                resource_type="problems", to_add=desired_ids, to_remove=[], unchanged=[]
             )
 
-    def _compare_teams(self, desired: ContestConfig, contest_id: str) -> ResourceChange:
+        current_ids = [str(p.get("externalid") or p.get("id")) for p in current]
+        diff = _diff_resource(desired_ids, current_ids)
+        logger.debug(
+            f"Problem comparison: {len(diff.to_add)} to add, {len(diff.unchanged)} unchanged"
+        )
+        return ResourceChange(
+            resource_type="problems",
+            to_add=diff.to_add,
+            to_remove=[],
+            unchanged=diff.unchanged,
+        )
+
+    def _diff_teams(self, desired: ContestConfig, contest_id: str) -> ResourceChange:
+        """Compare teams using deterministic composite names as the join key.
+
+        DOMjudge stores team names as ``"team####|name|affiliation|country"``.
+        We reconstruct that exact form for desired teams (using the stored
+        seed for stable hashing) so the comparison is an exact string match.
+        Display names are projected back through the ``key → name`` map.
         """
-        Compare teams to detect additions using deterministic composite names.
+        secrets = get_secrets_manager()
+        composite_to_display: dict[str, str] = {
+            f"{generate_team_username(secrets, t.composite_key)}|{t.composite_key}": t.name
+            for t in desired.teams
+        }
 
-        Uses stored seed from secrets manager for deterministic hashing, ensuring
-        consistent team IDs across runs. This provides accurate matching using the
-        API's composite names as the source of truth.
-
-        Args:
-            desired: Desired configuration
-            contest_id: Contest ID
-
-        Returns:
-            ResourceChange for teams
-        """
         try:
-            # Get secrets manager for deterministic hashing
-            secrets = get_secrets_manager()
-
-            # Get current teams in contest from API (source of truth)
-            current_teams = self.client.teams.list_for_contest(contest_id)
-
-            # Build set of composite names from API
-            # Format: "team####|name|affiliation|country"
-            current_composite_names = {t.get("name") for t in current_teams if t.get("name")}
-
-            # Reconstruct composite names for desired teams using deterministic hashing
-            desired_composite_names = {}
-            for team in desired.teams:
-                # Generate deterministic username (uses stored seed from secrets manager)
-                username = generate_team_username(secrets, team.composite_key)
-
-                # Build composite name exactly as it appears in API
-                composite_name = f"{username}|{team.composite_key}"
-
-                # Map composite name to display name for user-friendly output
-                desired_composite_names[composite_name] = team.name
-
-            # Calculate changes by comparing composite names (exact API match)
-            desired_set = set(desired_composite_names.keys())
-            to_add_composite = list(desired_set - current_composite_names)
-            unchanged_composite = list(desired_set & current_composite_names)
-
-            # Convert to display names for output
-            to_add = [desired_composite_names[comp] for comp in to_add_composite]
-            unchanged = [desired_composite_names[comp] for comp in unchanged_composite]
-
-            logger.debug(
-                f"Team comparison: {len(to_add)} to add, {len(unchanged)} unchanged "
-                f"(using deterministic composite names)"
-            )
-
-            return ResourceChange(
-                resource_type="teams",
-                to_add=to_add,
-                to_remove=[],
-                unchanged=unchanged,
-            )
-        except Exception as e:
+            current = self.client.teams.list_for_contest(contest_id)
+        except APIError as e:
             logger.warning(f"Failed to compare teams: {e}", exc_info=True)
-            # On error, assume all need to be added (idempotent operation will handle)
             return ResourceChange(
                 resource_type="teams",
                 to_add=[t.name for t in desired.teams if t.name],
                 to_remove=[],
                 unchanged=[],
             )
+
+        current_keys = [str(name) for t in current if (name := t.get("name"))]
+        diff = _diff_resource(
+            composite_to_display.keys(), current_keys, display=composite_to_display
+        )
+        logger.debug(
+            f"Team comparison: {len(diff.to_add)} to add, {len(diff.unchanged)} unchanged "
+            "(using deterministic composite names)"
+        )
+        return ResourceChange(
+            resource_type="teams",
+            to_add=diff.to_add,
+            to_remove=[],
+            unchanged=diff.unchanged,
+        )
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _require_shortname(contest: ContestConfig) -> str:
+    if contest.shortname is None:
+        raise ContestError("Contest configuration is missing required 'shortname'")
+    return contest.shortname

--- a/dom/core/services/contest/verification.py
+++ b/dom/core/services/contest/verification.py
@@ -8,70 +8,68 @@ from dom.core.services.base import ServiceContext
 from dom.core.services.problem.apply import ProblemService
 from dom.core.services.protocols import DomJudgeAPIProtocol
 from dom.core.services.team.apply import TeamService
+from dom.exceptions import ContestError, ProblemError, TeamError
 from dom.types.api.models import Contest
 from dom.types.contest import ContestConfig
 from dom.types.secrets import SecretsProvider
 from dom.types.team import Team
 
+_TEMP_NAME_SUFFIX_LENGTH = 8
+_TEMP_CONTEST_START = datetime.fromisoformat("2020-01-01T00:00:00+01:00")
+_TEMP_CONTEST_DURATION = "10:00:00.000"
+
 
 def create_temp_contest(
     client: DomJudgeAPIProtocol, contest: ContestConfig, secrets_mgr: SecretsProvider
 ) -> tuple[Contest, Team]:
-    """
-    Create a temporary contest for verification purposes.
+    """Create a throwaway contest plus a single team, used to verify problems.
 
-    Args:
-        client: DOMjudge API client
-        contest: Contest configuration
-        secrets_mgr: Secrets manager for password generation
-
-    Returns:
-        Tuple of (Contest, Team) for the temporary contest
+    Raises ``ContestError`` / ``ProblemError`` / ``TeamError`` on failure.
     """
-    # Generate random suffix for uniqueness
-    alphabet = string.ascii_letters + string.digits
-    random_suffix = "".join(secrets.choice(alphabet) for _ in range(8))
-    temp_name = f"Temp-{contest.shortname}-{random_suffix}"
+    temp_name = f"Temp-{contest.shortname}-{_random_suffix()}"
 
     api_contest = Contest(
         name=f"Temp {contest.name or contest.shortname}",
         shortname=temp_name,
         formal_name=contest.formal_name or contest.name,
-        start_time=datetime.fromisoformat("2020-01-01T00:00:00+01:00"),
-        duration="10:00:00.000",
+        start_time=_TEMP_CONTEST_START,
+        duration=_TEMP_CONTEST_DURATION,
         allow_submit=True,
     )
 
     result = client.contests.create(api_contest)
-    contest_id = result.id
-    created = result.created
-
-    assert created, "Failed to create temporary contest"
-    assert contest_id is not None, "Contest ID is None"
+    if not result.created:
+        raise ContestError(f"Failed to create temporary contest '{temp_name}'")
+    if result.id is None:
+        raise ContestError(f"Temporary contest '{temp_name}' was created without an ID")
 
     temp_team = Team(
         name=temp_name,
         username=temp_name,
         password=secrets_mgr.generate_deterministic_password(seed=temp_name, length=12),
     )
+    context = ServiceContext(client=client, contest_id=result.id, contest_shortname=temp_name)
 
-    # Create service context
-    context = ServiceContext(client=client, contest_id=contest_id, contest_shortname=temp_name)
-
-    # Use declarative services
     problem_service = ProblemService(client)
     team_service = TeamService(client)
 
-    # Apply problems
     problem_results = problem_service.create_many(contest.problems, context, stop_on_error=False)
     problem_summary = problem_service.get_summary(problem_results)
-    assert problem_summary["failed"] == 0, f"{problem_summary['failed']} problems failed to add"
+    if problem_summary["failed"] > 0:
+        raise ProblemError(
+            f"{problem_summary['failed']} problem(s) failed to add to temporary contest"
+        )
 
-    # Apply team
     team_results = team_service.create_many([temp_team], context, stop_on_error=False)
     team_summary = team_service.get_summary(team_results)
-    assert team_summary["failed"] == 0, f"{team_summary['failed']} teams failed to add"
-
-    assert temp_team.id is not None, "Team ID is None"
+    if team_summary["failed"] > 0:
+        raise TeamError(f"{team_summary['failed']} team(s) failed to add to temporary contest")
+    if temp_team.id is None:
+        raise TeamError(f"Temporary team '{temp_name}' was created without an ID")
 
     return api_contest, temp_team
+
+
+def _random_suffix() -> str:
+    alphabet = string.ascii_letters + string.digits
+    return "".join(secrets.choice(alphabet) for _ in range(_TEMP_NAME_SUFFIX_LENGTH))

--- a/dom/core/services/infra/service.py
+++ b/dom/core/services/infra/service.py
@@ -150,17 +150,18 @@ class InfraService:
         try:
             with Path(self._compose_file).open() as f:
                 compose_data = yaml.safe_load(f)
-            services = {
-                name: cfg.get("container_name", name)
-                for name, cfg in compose_data.get("services", {}).items()
-            }
-            logger.debug(
-                f"Found {len(services)} services in docker-compose.yml: {list(services.keys())}"
-            )
-            return services
-        except Exception as e:
+        except (OSError, yaml.YAMLError) as e:
             logger.error(f"Failed to parse docker-compose.yml: {e}", exc_info=True)
             return {}
+
+        services = {
+            name: cfg.get("container_name", name)
+            for name, cfg in (compose_data or {}).get("services", {}).items()
+        }
+        logger.debug(
+            f"Found {len(services)} services in docker-compose.yml: {list(services.keys())}"
+        )
+        return services
 
     def _container_status(self, container_name: str) -> tuple[ServiceStatus, dict]:
         """Inspect a container and classify its state + health."""
@@ -211,7 +212,7 @@ class InfraService:
                 return ServiceStatus.UNHEALTHY, base_details
             return ServiceStatus.HEALTHY, base_details
 
-        except Exception as e:
+        except (FileNotFoundError, OSError, subprocess.SubprocessError) as e:
             logger.error(
                 f"Failed to check container status: {e}",
                 exc_info=True,

--- a/dom/core/services/infra/state.py
+++ b/dom/core/services/infra/state.py
@@ -2,6 +2,7 @@
 
 import re
 import subprocess  # nosec B404
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 
@@ -13,6 +14,24 @@ from dom.types.infra import InfraConfig
 from dom.utils.cli import get_container_prefix, get_secrets_manager
 
 logger = get_logger(__name__)
+
+
+def _run_docker(args: list[str], *, check: bool = False) -> subprocess.CompletedProcess | None:
+    """Invoke ``docker`` and return the completed process, or ``None`` on failure.
+
+    "Failure" here means the docker CLI itself couldn't run — not
+    installed, permission denied, killed. A nonzero exit code is *not*
+    a failure: some callers rely on it to detect "container doesn't
+    exist". Anything outside this contract is a programmer bug and is
+    re-raised.
+    """
+    try:
+        return subprocess.run(  # nosec B603 B607
+            args, capture_output=True, text=True, check=check
+        )
+    except (FileNotFoundError, OSError, subprocess.SubprocessError) as e:
+        logger.warning(f"docker {' '.join(args[1:3])}: {e}")
+        return None
 
 
 class InfraChangeType(str, Enum):
@@ -50,28 +69,59 @@ class InfraChangeSet:
         )
 
     def summary(self) -> str:
-        """Get human-readable summary of changes."""
-        if self.change_type == InfraChangeType.CREATE:
-            return "[green]CREATE[/green] new infrastructure"
+        """Render a markup-decorated summary line for the CLI to print."""
+        return _SUMMARY_RENDERERS[self.change_type](self)
 
-        if self.change_type == InfraChangeType.NO_CHANGE:
-            return "[dim]NO CHANGES[/dim] to infrastructure"
 
-        if self.change_type == InfraChangeType.SCALE_JUDGES:
-            assert self.old_config is not None  # SCALE_JUDGES always has old_config
-            if self.judge_diff > 0:
-                return f"[green]SCALE UP[/green] judgehosts: {self.old_config.judges} → {self.new_config.judges} (safe live change)"
-            else:
-                return f"[yellow]SCALE DOWN[/yellow] judgehosts: {self.old_config.judges} → {self.new_config.judges} (safe live change)"
+def _summary_scale(cs: "InfraChangeSet") -> str:
+    direction = "[green]SCALE UP[/green]" if cs.judge_diff > 0 else "[yellow]SCALE DOWN[/yellow]"
+    old = cs.old_config.judges if cs.old_config else "?"
+    return f"{direction} judgehosts: {old} → {cs.new_config.judges} " "(safe live change)"
 
-        if self.change_type == InfraChangeType.PORT_CHANGE:
-            assert self.old_config is not None  # PORT_CHANGE always has old_config
-            return f"[red]PORT CHANGE[/red]: {self.old_config.port} → {self.new_config.port} [bold](requires restart)[/bold]"
 
-        if self.change_type == InfraChangeType.PASSWORD_CHANGE:
-            return "[yellow]PASSWORD CHANGE[/yellow] [bold](requires restart)[/bold]"
+def _summary_port(cs: "InfraChangeSet") -> str:
+    old = cs.old_config.port if cs.old_config else "?"
+    return (
+        f"[red]PORT CHANGE[/red]: {old} → {cs.new_config.port} " "[bold](requires restart)[/bold]"
+    )
 
-        return "[red]MULTIPLE CHANGES[/red] [bold](requires full restart)[/bold]"
+
+_SUMMARY_RENDERERS: dict[InfraChangeType, Callable[["InfraChangeSet"], str]] = {
+    InfraChangeType.CREATE: lambda _cs: "[green]CREATE[/green] new infrastructure",
+    InfraChangeType.NO_CHANGE: lambda _cs: "[dim]NO CHANGES[/dim] to infrastructure",
+    InfraChangeType.SCALE_JUDGES: _summary_scale,
+    InfraChangeType.PORT_CHANGE: _summary_port,
+    InfraChangeType.PASSWORD_CHANGE: lambda _cs: (
+        "[yellow]PASSWORD CHANGE[/yellow] [bold](requires restart)[/bold]"
+    ),
+    InfraChangeType.FULL_RESTART: lambda _cs: (
+        "[red]MULTIPLE CHANGES[/red] [bold](requires full restart)[/bold]"
+    ),
+}
+
+
+# Each entry: which combination of changed fields maps to which change type.
+# Anything not listed (i.e. >1 field changed in an unrecognized combination)
+# falls through to FULL_RESTART.
+_CHANGE_TYPE_BY_FIELDS: dict[frozenset[str], InfraChangeType] = {
+    frozenset(): InfraChangeType.NO_CHANGE,
+    frozenset({"judges"}): InfraChangeType.SCALE_JUDGES,
+    frozenset({"port"}): InfraChangeType.PORT_CHANGE,
+    frozenset({"password"}): InfraChangeType.PASSWORD_CHANGE,
+}
+
+
+def _detect_changed_fields(old: InfraConfig, new: InfraConfig) -> frozenset[str]:
+    """Return the set of infra fields whose value differs between old and new."""
+    field_extractors: dict[str, Callable[[InfraConfig], object]] = {
+        "port": lambda c: c.port,
+        "password": lambda c: c.password,
+        "judges": lambda c: c.judges,
+    }
+    changed = {name for name, get in field_extractors.items() if get(old) != get(new)}
+    for name in changed:
+        logger.debug(f"Infra field changed: {name}")
+    return frozenset(changed)
 
 
 class InfraStateComparator:
@@ -91,17 +141,8 @@ class InfraStateComparator:
         self.container_prefix = get_container_prefix()
 
     def compare_infrastructure(self, new_config: InfraConfig) -> InfraChangeSet:
-        """
-        Compare new configuration with current deployed state.
-
-        Args:
-            new_config: New infrastructure configuration
-
-        Returns:
-            InfraChangeSet describing changes
-        """
+        """Compute an :class:`InfraChangeSet` from the live Docker state."""
         old_config = self._load_current_state()
-
         if old_config is None:
             return InfraChangeSet(
                 change_type=InfraChangeType.CREATE,
@@ -109,176 +150,71 @@ class InfraStateComparator:
                 new_config=new_config,
             )
 
-        # Detect what changed
-        changes = []
-
-        if old_config.port != new_config.port:
-            changes.append("port")
-            logger.debug(f"Port change detected: {old_config.port} → {new_config.port}")
-
-        if old_config.password != new_config.password:
-            changes.append("password")
-            logger.debug("Password change detected")
-
-        judges_changed = old_config.judges != new_config.judges
-        if judges_changed:
-            changes.append("judges")
-            logger.debug(f"Judgehost count change: {old_config.judges} → {new_config.judges}")
-
-        # Determine change type
-        if not changes:
-            return InfraChangeSet(
-                change_type=InfraChangeType.NO_CHANGE,
-                old_config=old_config,
-                new_config=new_config,
-            )
-
-        if changes == ["judges"]:
-            return InfraChangeSet(
-                change_type=InfraChangeType.SCALE_JUDGES,
-                old_config=old_config,
-                new_config=new_config,
-                judge_diff=new_config.judges - old_config.judges,
-            )
-
-        if "port" in changes and len(changes) == 1:
-            return InfraChangeSet(
-                change_type=InfraChangeType.PORT_CHANGE,
-                old_config=old_config,
-                new_config=new_config,
-            )
-
-        if "password" in changes and len(changes) == 1:
-            return InfraChangeSet(
-                change_type=InfraChangeType.PASSWORD_CHANGE,
-                old_config=old_config,
-                new_config=new_config,
-            )
-
-        # Multiple changes
+        changed = _detect_changed_fields(old_config, new_config)
         return InfraChangeSet(
-            change_type=InfraChangeType.FULL_RESTART,
+            change_type=_CHANGE_TYPE_BY_FIELDS.get(changed, InfraChangeType.FULL_RESTART),
             old_config=old_config,
             new_config=new_config,
+            judge_diff=new_config.judges - old_config.judges,
         )
 
     def _load_current_state(self) -> InfraConfig | None:
+        """Query Docker for the current deployed infrastructure state.
+
+        Returns ``None`` for a fresh deployment (no domserver container)
+        or when Docker can't be reached at all.
         """
-        Query Docker to get current deployed infrastructure state.
-
-        Uses Docker as the single source of truth - no state files needed!
-
-        Returns:
-            Current infrastructure config or None if not deployed
-        """
-        try:
-            # Check if domserver container exists
-            domserver_name = ContainerNames.DOMSERVER.with_prefix(self.container_prefix)
-
-            # Get container info (will fail if not exists)
-            result = subprocess.run(
-                ["docker", "inspect", domserver_name],
-                capture_output=True,
-                text=True,
-                check=False,  # nosec B603 B607
-            )
-
-            if result.returncode != 0:
-                logger.debug("No domserver container found (new deployment)")
-                return None
-
-            # Extract port from container
-            port = self._get_container_port(domserver_name)
-            if port is None:
-                logger.warning("Could not determine port from domserver container")
-                return None
-
-            # Count judgehost containers
-            judges = self._count_judgehost_containers()
-
-            # Get password from secrets (already stored there)
-            secrets = get_secrets_manager()
-            password = secrets.get("admin_password")
-
-            if not password:
-                logger.warning("Admin password not found in secrets")
-                return None
-
-            logger.debug(f"Current infrastructure state from Docker: port={port}, judges={judges}")
-
-            return InfraConfig(
-                port=port,
-                judges=judges,
-                password=SecretStr(password),
-            )
-
-        except Exception as e:
-            logger.warning(f"Failed to query Docker for infrastructure state: {e}")
+        domserver = ContainerNames.DOMSERVER.with_prefix(self.container_prefix)
+        result = _run_docker(["docker", "inspect", domserver])
+        if result is None or result.returncode != 0:
+            logger.debug("No domserver container found (new deployment)")
             return None
+
+        port = self._get_container_port(domserver)
+        if port is None:
+            logger.warning("Could not determine port from domserver container")
+            return None
+
+        password = get_secrets_manager().get("admin_password")
+        if not password:
+            logger.warning("Admin password not found in secrets")
+            return None
+
+        judges = self._count_judgehost_containers()
+        logger.debug(f"Current infrastructure state from Docker: port={port}, judges={judges}")
+        return InfraConfig(port=port, judges=judges, password=SecretStr(password))
 
     def _get_container_port(self, container_name: str) -> int | None:
-        """
-        Get the exposed port from a container.
-
-        Args:
-            container_name: Name of the container
-
-        Returns:
-            Port number or None if not found
-        """
+        """Return the host port mapped to container port 80, or ``None``."""
+        result = _run_docker(["docker", "port", container_name, "80"])
+        if result is None or result.returncode != 0:
+            return None
+        match = re.search(r":(\d+)", result.stdout.strip())
+        if match is None:
+            return None
         try:
-            # Get port mapping using docker port command
-            result = subprocess.run(
-                ["docker", "port", container_name, "80"],
-                capture_output=True,
-                text=True,
-                check=False,  # nosec B603 B607
-            )
-
-            if result.returncode != 0:
-                return None
-
-            # Parse output like "0.0.0.0:8080"
-            match = re.search(r":(\d+)", result.stdout.strip())
-            if match:
-                port = int(match.group(1))
-                logger.debug(f"Found port {port} for container {container_name}")
-                return port
-
+            port = int(match.group(1))
+        except ValueError:
+            logger.warning(f"Unexpected port output for {container_name}: {result.stdout!r}")
             return None
-
-        except Exception as e:
-            logger.warning(f"Failed to get port for {container_name}: {e}")
-            return None
+        logger.debug(f"Found port {port} for container {container_name}")
+        return port
 
     def _count_judgehost_containers(self) -> int:
-        """
-        Count the number of running judgehost containers.
-
-        Returns:
-            Number of judgehost containers
-        """
-        try:
-            # List containers with judgehost in the name
-            result = subprocess.run(
-                [
-                    "docker",
-                    "ps",
-                    "--filter",
-                    f"name={self.container_prefix}-judgehost",
-                    "--format",
-                    "{{.Names}}",
-                ],
-                capture_output=True,
-                text=True,
-                check=True,  # nosec B603 B607
-            )
-
-            # Count non-empty lines
-            count = len([line for line in result.stdout.strip().split("\n") if line])
-            logger.debug(f"Found {count} judgehost containers")
-            return count
-
-        except Exception as e:
-            logger.warning(f"Failed to count judgehost containers: {e}")
+        """Return the number of running judgehost containers (0 on failure)."""
+        result = _run_docker(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                f"name={self.container_prefix}-judgehost",
+                "--format",
+                "{{.Names}}",
+            ],
+            check=True,
+        )
+        if result is None:
             return 0
+        count = sum(1 for line in result.stdout.splitlines() if line.strip())
+        logger.debug(f"Found {count} judgehost containers")
+        return count

--- a/dom/core/services/problem/apply.py
+++ b/dom/core/services/problem/apply.py
@@ -43,21 +43,6 @@ class ProblemService(Service[ProblemPackage], BulkOperationMixin[ProblemPackage]
 
         try:
             problem_id = self.client.problems.add_to_contest(context.contest_id, entity)
-            entity.id = problem_id
-
-            logger.info(
-                "Successfully added problem to contest",
-                extra={
-                    "problem_name": entity.yaml.name,
-                    "problem_id": problem_id,
-                    "contest_id": context.contest_id,
-                },
-            )
-
-            return ServiceResult.ok(
-                entity, f"Problem '{entity.yaml.name}' added successfully", created=True
-            )
-
         except APIError as e:
             logger.error(
                 f"Failed to add problem '{entity.yaml.name}' to contest {context.contest_id}",
@@ -73,20 +58,18 @@ class ProblemService(Service[ProblemPackage], BulkOperationMixin[ProblemPackage]
                 f"Problem '{entity.yaml.name}' failed",
             )
 
-        except Exception as e:
-            logger.error(
-                f"Unexpected error adding problem '{entity.yaml.name}' to contest {context.contest_id}",
-                exc_info=True,
-                extra={
-                    "problem_name": entity.yaml.name,
-                    "contest_id": context.contest_id,
-                    "error_type": type(e).__name__,
-                },
-            )
-            return ServiceResult.fail(
-                ProblemError(f"Unexpected error adding problem '{entity.yaml.name}': {e}"),
-                f"Unexpected error for '{entity.yaml.name}'",
-            )
+        entity.id = problem_id
+        logger.info(
+            "Successfully added problem to contest",
+            extra={
+                "problem_name": entity.yaml.name,
+                "problem_id": problem_id,
+                "contest_id": context.contest_id,
+            },
+        )
+        return ServiceResult.ok(
+            entity, f"Problem '{entity.yaml.name}' added successfully", created=True
+        )
 
     def create_many(
         self,

--- a/dom/core/services/problem/verify.py
+++ b/dom/core/services/problem/verify.py
@@ -6,6 +6,7 @@ from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn, TimeEl
 from dom.core.services.contest.verification import create_temp_contest
 from dom.core.services.protocols import DomJudgeAPIProtocol
 from dom.core.services.submission.submit import submit_problem
+from dom.exceptions import ProblemError
 from dom.types.contest import ContestConfig
 from dom.types.secrets import SecretsProvider
 
@@ -55,7 +56,11 @@ async def _run_submissions(client: DomJudgeAPIProtocol, contest_id: str, team, p
     ) as progress:
         task = progress.add_task("Scheduling", total=len(problems))
         for problem in problems:
-            assert problem.id is not None
+            if problem.id is None:
+                raise ProblemError(
+                    f"Problem '{problem.yaml.name}' has no id; "
+                    "it must be added to the contest before verification"
+                )
             problem_tasks = await submit_problem(
                 client=client, contest_id=contest_id, problem=problem, team=team
             )

--- a/dom/core/services/team/apply.py
+++ b/dom/core/services/team/apply.py
@@ -56,17 +56,22 @@ class TeamService(Service[Team], BulkOperationMixin[Team]):
                     entity.affiliation, entity.country, context
                 )
 
-            # Use composite key for unique team identification
-            # Teams are uniquely identified by (name, affiliation, country)
-            # This allows different organizations to have teams with the same name
+            # Teams are uniquely identified across (name, affiliation, country)
+            # so different organizations can have teams with the same display name.
             composite_key = entity.composite_key
 
-            # Generate consistent team ID based on composite key
-            # This ensures the same team gets the same ID across contests
+            # NOTE: Python's built-in hash() is salted per process (PYTHONHASHSEED),
+            # so this team_id is stable WITHIN one apply run but NOT across runs.
+            # DOMjudge's idempotency relies on the composite ``name`` below (which
+            # uses entity.username, generated via deterministic_hash) — the API
+            # treats name collisions as the same team, so a fresh team_id on a
+            # re-run is harmless. Don't replace with deterministic_hash without
+            # understanding the migration implications for existing deployments.
             team_id = str(hash(composite_key) % HASH_MODULUS)
 
-            # Use composite key as the global team name for consistency
-            # Username is already set to team{hash} by the config loader
+            # The composite team name IS the join key. ``entity.username`` is
+            # ``team{deterministic_hash}`` set by the config loader, so this
+            # form is stable across runs.
             team_name = f"{entity.username}|{composite_key}"
 
             # Use original team name as display_name for clean scoreboard
@@ -134,21 +139,6 @@ class TeamService(Service[Team], BulkOperationMixin[Team]):
             )
             return ServiceResult.fail(TeamError(error_msg), f"Team '{entity.name}' failed")
 
-        except Exception as e:
-            error_msg = (
-                f"Unexpected error adding team '{entity.name}' to contest {context.contest_id}: {e}"
-            )
-            logger.error(
-                error_msg,
-                exc_info=True,
-                extra={
-                    "team_name": entity.name,
-                    "contest_id": context.contest_id,
-                    "error_type": type(e).__name__,
-                },
-            )
-            return ServiceResult.fail(TeamError(error_msg), f"Unexpected error for '{entity.name}'")
-
     def _create_organization(
         self, affiliation: str, country: str | None, context: ServiceContext
     ) -> str:
@@ -166,11 +156,10 @@ class TeamService(Service[Team], BulkOperationMixin[Team]):
         Returns:
             Organization ID
         """
-        # Use country or default to ensure consistent org ID generation
         org_country = country or DEFAULT_COUNTRY_CODE
-
-        # Generate unique org ID based on affiliation + country
-        # This ensures "MIT|USA" and "MIT|GBR" are treated as different organizations
+        # ``MIT|USA`` and ``MIT|GBR`` are different organizations.
+        # Same caveat as team_id: hash() is per-process, so org_id is stable
+        # within a run but not across runs. DOMjudge dedupes by name + country.
         org_composite_key = f"{affiliation}|{org_country}"
         org_id = str(hash(org_composite_key) % HASH_MODULUS)
 

--- a/tests/unit/operations/test_contest_operations.py
+++ b/tests/unit/operations/test_contest_operations.py
@@ -5,13 +5,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 import typer
 
-from dom.core.operations import Context, Steps, run
+from dom.core.operations import Context, run
 from dom.core.operations.contest.apply import apply_contests_op
 from dom.core.operations.contest.load_config import load_config_op
 from dom.core.operations.contest.load_contest_config import load_contest_config_op
 from dom.core.operations.contest.plan_changes import plan_contest_changes_op
 from dom.core.operations.contest.verify_problemset import verify_problemset_op
-from dom.core.services.contest.changes import ChangeType
 from dom.types.secrets import SecretsProvider
 
 
@@ -37,11 +36,26 @@ def _make_dom_config(num_contests: int = 1, problems: int = 2, teams: int = 3):
 # ---------------------------------------------------------------- ApplyContests
 
 
-def test_apply_runs_service_and_returns_steps(context):
+def _result(shortname="C0", skipped=()):
+    from dom.core.services.contest.apply import ContestApplyResult
+
+    return ContestApplyResult(
+        contest_shortname=shortname,
+        contest_id=f"id-{shortname}",
+        skipped_field_changes=list(skipped),
+    )
+
+
+def test_apply_runs_service_and_returns_results(context):
     config = _make_dom_config()
-    with patch("dom.core.operations.contest.apply._apply_all") as svc:
-        run(apply_contests_op(config), context)
+    with patch(
+        "dom.core.operations.contest.apply._apply_all",
+        return_value=[_result("C0")],
+    ) as svc:
+        result = run(apply_contests_op(config), context)
     svc.assert_called_once_with(config, context)
+    assert len(result) == 1
+    assert result[0].contest_shortname == "C0"
 
 
 def test_apply_rejects_empty_contests(context):
@@ -51,23 +65,39 @@ def test_apply_rejects_empty_contests(context):
 
 
 def test_apply_summary_for_single_contest(context, capsys):
-    config = _make_dom_config(num_contests=1, problems=4, teams=10)
-    with patch("dom.core.operations.contest.apply._apply_all"):
+    config = _make_dom_config(num_contests=1)
+    with patch(
+        "dom.core.operations.contest.apply._apply_all",
+        return_value=[_result("C0")],
+    ):
         run(apply_contests_op(config), context)
     out = capsys.readouterr().out
     assert "C0" in out
-    assert "4 problems" in out
-    assert "10 teams" in out
 
 
 def test_apply_summary_for_multiple_contests(context, capsys):
     config = _make_dom_config(num_contests=2)
-    with patch("dom.core.operations.contest.apply._apply_all"):
+    with patch(
+        "dom.core.operations.contest.apply._apply_all",
+        return_value=[_result("C0"), _result("C1")],
+    ):
         run(apply_contests_op(config), context)
     out = capsys.readouterr().out
     assert "2 contests" in out
-    assert "C0" in out
-    assert "C1" in out
+
+
+def test_apply_summary_flags_skipped_field_changes(context, capsys):
+    from dom.core.services.contest.changes import FieldChange
+
+    config = _make_dom_config(num_contests=1)
+    skipped = [FieldChange(field="duration", old_value="5:00", new_value="6:00")]
+    with patch(
+        "dom.core.operations.contest.apply._apply_all",
+        return_value=[_result("C0", skipped=skipped)],
+    ):
+        run(apply_contests_op(config), context)
+    out = capsys.readouterr().out
+    assert "skipped" in out
 
 
 # ---------------------------------------------------------------- PlanChanges
@@ -80,28 +110,12 @@ def test_plan_returns_per_contest_change_sets(context):
     with (
         patch("dom.core.operations.contest.plan_changes.wire_admin_api"),
         patch("dom.core.operations.contest.plan_changes.ContestStateComparator") as comparator_cls,
-        patch("dom.core.operations.contest.plan_changes._print_planned_changes"),
     ):
         comparator_cls.return_value.compare_contest.return_value = fake_change
         result = run(plan_contest_changes_op(config), context)
 
     assert len(result) == 2
     assert all(item["change_set"] is fake_change for item in result)
-
-
-def test_plan_invokes_presenter(context):
-    config = _make_dom_config()
-    fake_change = MagicMock(has_changes=True)
-
-    with (
-        patch("dom.core.operations.contest.plan_changes.wire_admin_api"),
-        patch("dom.core.operations.contest.plan_changes.ContestStateComparator") as comparator_cls,
-        patch("dom.core.operations.contest.plan_changes._print_planned_changes") as presenter,
-    ):
-        comparator_cls.return_value.compare_contest.return_value = fake_change
-        run(plan_contest_changes_op(config), context)
-
-    presenter.assert_called_once()
 
 
 def test_plan_summary_counts_changes(context, capsys):
@@ -111,7 +125,6 @@ def test_plan_summary_counts_changes(context, capsys):
     with (
         patch("dom.core.operations.contest.plan_changes.wire_admin_api"),
         patch("dom.core.operations.contest.plan_changes.ContestStateComparator") as comparator_cls,
-        patch("dom.core.operations.contest.plan_changes._print_planned_changes"),
     ):
         comparator_cls.return_value.compare_contest.side_effect = changes
         run(plan_contest_changes_op(config), context)
@@ -119,16 +132,17 @@ def test_plan_summary_counts_changes(context, capsys):
     assert "1 with changes" in capsys.readouterr().out
 
 
-def test_plan_presenter_handles_no_changes(capsys):
-    from dom.core.operations.contest.plan_changes import _print_planned_changes
+def test_render_planned_changes_handles_no_changes(capsys):
+    from dom.cli.contest.render import render_planned_changes
 
-    _print_planned_changes([])
+    render_planned_changes([])
     output = capsys.readouterr().out
     assert "No changes" in output
 
 
-def test_plan_presenter_renders_creates(capsys):
-    from dom.core.operations.contest.plan_changes import _print_planned_changes
+def test_render_planned_changes_renders_creates(capsys):
+    from dom.cli.contest.render import render_planned_changes
+    from dom.core.services.contest.changes import ChangeType
 
     change_set = MagicMock(
         change_type=ChangeType.CREATE,
@@ -137,7 +151,7 @@ def test_plan_presenter_renders_creates(capsys):
     )
     change_set.summary.return_value = "[CREATE] Contest C0"
 
-    _print_planned_changes([{"shortname": "C0", "change_set": change_set}])
+    render_planned_changes([{"shortname": "C0", "change_set": change_set}])
     output = capsys.readouterr().out
     assert "Planned Changes" in output
     assert "C0" in output
@@ -263,11 +277,10 @@ def test_verify_rejects_missing_files(context, tmp_path):
         run(verify_problemset_op(missing_contest, "ContestA", missing_infra), context)
 
 
-def test_apply_returns_steps_with_summary(context):
-    """apply_contests_op returns Steps with a custom summary string."""
+def test_apply_op_is_single_step_with_summary_callback(context):
+    """apply_contests_op is a single-step op returning ContestApplyResult list."""
     config = _make_dom_config()
     op = apply_contests_op(config)
-    plan = op.build(context)
-    assert isinstance(plan, Steps)
-    assert plan.summary
-    assert len(plan.steps) == 1
+    assert op.summary is not None
+    # Single-step ops auto-wrap their return; show_progress is disabled.
+    assert op.show_progress is False

--- a/tests/unit/operations/test_infrastructure_lifecycle.py
+++ b/tests/unit/operations/test_infrastructure_lifecycle.py
@@ -1,4 +1,4 @@
-"""Tests for destroy, check_status, and print_status infrastructure operations."""
+"""Tests for destroy, check_status infrastructure operations and the status renderer."""
 
 from unittest.mock import MagicMock, patch
 
@@ -7,7 +7,6 @@ import pytest
 from dom.core.operations import Context, run
 from dom.core.operations.infrastructure.check_status import check_infra_status_op
 from dom.core.operations.infrastructure.destroy import destroy_infrastructure_op
-from dom.core.operations.infrastructure.print_status import print_infra_status_op
 from dom.types.infra import InfrastructureStatus, ServiceStatus
 from dom.types.secrets import SecretsProvider
 
@@ -80,50 +79,42 @@ def test_check_status_summary_for_unhealthy(context, capsys):
     assert "issues" in capsys.readouterr().out.lower()
 
 
-# ---------------------------------------------------------------- Print status
+# ---------------------------------------------------------------- Status renderer (CLI layer)
 
 
-def test_print_status_calls_human_presenter_by_default(context):
-    fake_status = _make_status(docker_available=True)
-    fake_status.services["domserver"] = ServiceStatus.HEALTHY
+def test_render_status_human_readable_prints_to_console(capsys):
+    from dom.cli.infrastructure.render import render_status
 
-    with (
-        patch("dom.core.operations.infrastructure.print_status.InfraService") as svc_cls,
-        patch(
-            "dom.core.operations.infrastructure.print_status._print_status_human_readable"
-        ) as human,
-        patch("dom.core.operations.infrastructure.print_status._print_status_json") as as_json,
-    ):
-        svc_cls.return_value.check_status.return_value = fake_status
-        run(print_infra_status_op(json_output=False), context)
+    status = _make_status(docker_available=True)
+    status.services["domserver"] = ServiceStatus.HEALTHY
 
-    human.assert_called_once_with(fake_status)
-    as_json.assert_not_called()
+    render_status(status, json_output=False)
+    out = capsys.readouterr().out
+    assert "HEALTHY" in out
+    assert "domserver" in out
 
 
-def test_print_status_calls_json_presenter_when_requested(context):
-    fake_status = _make_status(docker_available=True)
+def test_render_status_json_emits_valid_json(capsys):
+    import json as _json
 
-    with (
-        patch("dom.core.operations.infrastructure.print_status.InfraService") as svc_cls,
-        patch(
-            "dom.core.operations.infrastructure.print_status._print_status_human_readable"
-        ) as human,
-        patch("dom.core.operations.infrastructure.print_status._print_status_json") as as_json,
-    ):
-        svc_cls.return_value.check_status.return_value = fake_status
-        run(print_infra_status_op(json_output=True), context)
+    from dom.cli.infrastructure.render import render_status
 
-    as_json.assert_called_once_with(fake_status)
-    human.assert_not_called()
+    status = _make_status(docker_available=True)
+    status.services["domserver"] = ServiceStatus.HEALTHY
+
+    render_status(status, json_output=True)
+    out = capsys.readouterr().out.strip()
+    parsed = _json.loads(out)
+    assert parsed["docker_available"] is True
 
 
-def test_print_status_returns_status_value(context):
-    fake_status = _make_status(docker_available=True)
-    with (
-        patch("dom.core.operations.infrastructure.print_status.InfraService") as svc_cls,
-        patch("dom.core.operations.infrastructure.print_status._print_status_human_readable"),
-    ):
-        svc_cls.return_value.check_status.return_value = fake_status
-        result = run(print_infra_status_op(), context)
-    assert result is fake_status
+def test_render_status_handles_unavailable_docker(capsys):
+    from dom.cli.infrastructure.render import render_status
+
+    status = _make_status(docker_available=False)
+    status.docker_error = "daemon down"
+
+    render_status(status)
+    out = capsys.readouterr().out
+    assert "Not available" in out
+    assert "daemon down" in out

--- a/tests/unit/services/test_contest_apply.py
+++ b/tests/unit/services/test_contest_apply.py
@@ -79,9 +79,11 @@ def test_apply_contest_creates_when_change_type_is_create(service, client):
     service._comparator_mock.compare_contest.return_value = _change_set(ChangeType.CREATE)
     contest = _contest()
 
-    contest_id = service.apply_contest(contest)
+    result = service.apply_contest(contest)
 
-    assert contest_id == "contest-1"
+    assert result.contest_id == "contest-1"
+    assert result.contest_shortname == "C0"
+    assert result.skipped_field_changes == []
     client.contests.create.assert_called_once()
     create_arg = client.contests.create.call_args.kwargs["contest_data"]
     assert create_arg.shortname == "C0"
@@ -92,10 +94,56 @@ def test_apply_contest_skips_creation_when_no_change(service, client):
     service._comparator_mock._fetch_current_contest.return_value = {"id": "existing-1"}
     contest = _contest()
 
-    contest_id = service.apply_contest(contest)
+    result = service.apply_contest(contest)
 
-    assert contest_id == "existing-1"
+    assert result.contest_id == "existing-1"
+    assert result.skipped_field_changes == []
     client.contests.create.assert_not_called()
+
+
+def test_apply_contest_returns_skipped_field_changes(service):
+    from dom.core.services.contest.changes import FieldChange
+
+    fc = FieldChange(field="duration", old_value="5:00", new_value="6:00")
+    service._comparator_mock.compare_contest.return_value = _change_set(
+        ChangeType.NO_CHANGE, field_changes=[fc]
+    )
+    service._comparator_mock._fetch_current_contest.return_value = {"id": "existing-1"}
+
+    result = service.apply_contest(_contest())
+
+    assert result.skipped_field_changes == [fc]
+
+
+def test_apply_contest_accepts_injected_collaborators(client, secrets):
+    """Constructor injection: passing services directly bypasses module-level patches."""
+    from unittest.mock import MagicMock
+
+    from dom.core.services.contest.apply import ContestApplicationService
+
+    problem = MagicMock()
+    problem.create_many.return_value = []
+    problem.get_summary.return_value = {"failed": 0}
+    team = MagicMock()
+    team.create_many.return_value = []
+    team.get_summary.return_value = {"failed": 0}
+    comparator = MagicMock()
+    comparator.compare_contest.return_value = _change_set(ChangeType.CREATE)
+
+    svc = ContestApplicationService(
+        client,
+        secrets,
+        problem_service=problem,
+        team_service=team,
+        state_comparator=comparator,
+    )
+
+    assert svc.problem_service is problem
+    assert svc.team_service is team
+    assert svc.state_comparator is comparator
+
+    result = svc.apply_contest(_contest())
+    assert result.contest_id == "contest-1"
 
 
 def test_apply_contest_creates_team_group_for_scoreboard(service, client):
@@ -158,6 +206,7 @@ def test_apply_all_iterates_over_all_contests(secrets):
     services, so we exercise it from there."""
     from dom.core.operations.contest.apply import _apply_all
     from dom.core.operations.framework import Context
+    from dom.core.services.contest.apply import ContestApplyResult
 
     config = MagicMock()
     config.infra = MagicMock()
@@ -167,11 +216,18 @@ def test_apply_all_iterates_over_all_contests(secrets):
     with (
         patch("dom.core.operations.contest.apply.wire_admin_api") as wire,
         patch("dom.core.operations.contest.apply.ContestApplicationService") as service_cls,
+        patch("dom.core.operations.contest.apply.ProblemService"),
+        patch("dom.core.operations.contest.apply.TeamService"),
+        patch("dom.core.operations.contest.apply.ContestStateComparator"),
     ):
         instance = MagicMock()
+        instance.apply_contest.side_effect = [
+            ContestApplyResult(contest_shortname=s, contest_id=f"id-{s}") for s in ("A", "B", "C")
+        ]
         service_cls.return_value = instance
         wire.return_value = MagicMock()
 
-        _apply_all(config, ctx)
+        results = _apply_all(config, ctx)
 
     assert instance.apply_contest.call_count == 3
+    assert [r.contest_shortname for r in results] == ["A", "B", "C"]

--- a/tests/unit/services/test_contest_state.py
+++ b/tests/unit/services/test_contest_state.py
@@ -140,8 +140,10 @@ class TestContestStateComparator:
         assert result is None
 
     def test_fetch_current_contest_handles_api_errors(self, comparator, mock_client):
-        """Test that API errors are handled gracefully."""
-        mock_client.contests.list_all.side_effect = Exception("API Error")
+        """Transient API/network errors fall through to ``None`` (treat as new)."""
+        from dom.exceptions import APINetworkError
+
+        mock_client.contests.list_all.side_effect = APINetworkError("API Error")
 
         result = comparator._fetch_current_contest("test2025")
 


### PR DESCRIPTION
## Summary

A focused cleanup pass on top of the recently-merged code-review followups (#92). Extracts presentation out of services and operations, makes the contest service declarative, replaces the infra change-type if/elif with a lookup table, tightens exception handling, and removes a few patches of dead code.

Net diff: **+944 / −985** across 27 files. One commit on top of main.

## What changed

### Presentation pulled out of core layers
- All ``console.print`` calls removed from ``dom/core/services/`` and ``dom/core/operations/``. Operations return typed data; rendering lives in ``dom/cli/{contest,infrastructure}/render.py``.
- Replaces the duplicate ``print_infra_status_op`` (operation that bundled rendering) with ``check_infra_status_op`` + ``render_status``.

### Contest service made declarative
- ``apply_contest`` reads top-down: compare → resolve-or-create → provision-team-group → apply-resources, each step in its own small method.
- ``ContestApplicationService`` accepts ``ProblemService`` / ``TeamService`` / ``ContestStateComparator`` via constructor injection; operations layer wires them.
- Field comparison switched from a hand-rolled if/elif loop to a declarative list of ``FieldSpec`` records walked uniformly. ``_diff_resource`` generalizes the desired-vs-current set diff for both problems and teams.

### Infra change detection: lookup tables
- ``InfraStateComparator.compare_infrastructure`` → ``frozenset(changed_fields) → InfraChangeType`` lookup, replacing 6 if/elif branches.
- ``InfraChangeSet.summary`` dispatches through a ``_SUMMARY_RENDERERS`` dict.

### Tighter exception handling
- Catch ``APIError`` instead of ``(APIError, ConnectionError, TimeoutError, OSError)`` — the API client already wraps low-level network errors as ``APINetworkError``. Trusting the abstraction.
- Subprocess calls in ``infra/state.py`` go through one ``_run_docker`` helper that owns the ``FileNotFoundError`` / ``OSError`` / ``SubprocessError`` catch. Three duplicated try/except blocks → one.
- Drop dead defensive ``except Exception`` branches in ``ProblemService.create`` and ``TeamService.create``; ``create_many``'s outer ``as_completed`` loop is the safety net.
- Narrow yaml/subprocess catches in ``infra/service.py``.

### Misc cleanups
- All ``assert`` statements in production paths replaced with typed raises (``ContestError`` / ``ProblemError`` / ``TeamError`` / ``FileNotFoundError`` / ``RuntimeError``). Asserts get stripped by ``python -O``.
- Consolidated ``dom/cli/{contest,infrastructure}/helpers.py`` into one parameterized ``load_with_secrets`` in ``dom/cli/_helpers.py``.
- Dropped ``BulkOperationMixin.create_many`` (dead — both services override). ``get_summary`` is now ``@staticmethod``, removing the ``# type: ignore[attr-defined]``.
- Documented the per-process (not cross-process) behavior of Python's ``hash()`` in team/org id generation.

## Test plan

- [x] ``pytest tests/unit tests/integration`` — 303 pass
- [x] ``lint-imports`` — both contracts kept (layered architecture, no reverse dependencies)
- [x] ``ruff check`` — clean
- [x] ``mypy`` — clean across 121 source files
- [ ] Manual verification of ``dom contest plan`` rendering against a live DOMjudge instance
- [ ] Manual verification of ``dom infra status`` rendering (human + ``--json``)
- [ ] Manual verification of ``dom contest apply`` field-skip warnings against an existing contest