### PR TITLE
refactor(layers): pull UI out of core, split DockerClient, formalize render layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,6 +135,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.envrc
 
 # Spyder project settings
 .spyderproject

--- a/.importlinter
+++ b/.importlinter
@@ -50,12 +50,6 @@ forbidden_modules =
 ignore_imports =
     # logging_config wires the shared Console into RichHandler — it needs the singleton.
     dom.logging_config -> dom.ui.console
-    # The operations framework prints plan/dry-run/success/error lines and drives the
-    # rich.Progress widget. TODO: move presentation into dom.cli renderers.
-    dom.core.operations.framework -> dom.ui
-    dom.core.operations.framework -> dom.ui.console
-    # The cli_command decorator renders user-facing error output for every CLI command.
-    dom.utils.cli -> dom.ui
     # preview_csv renders a Rich table for the user during the init wizard.
     dom.utils.csv_preview -> dom.ui
     # warn_if_privileged_port surfaces a user-visible warning before infra apply.

--- a/dom/cli/__init__.py
+++ b/dom/cli/__init__.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import typer
 
 from dom import __version__, ui
+from dom.cli import runner
 from dom.cli.contest import contest_command
 from dom.cli.infrastructure import infra_command
 from dom.cli.init import init_command

--- a/dom/cli/contest/apply.py
+++ b/dom/cli/contest/apply.py
@@ -6,10 +6,10 @@ import typer
 
 from dom.cli.contest.helpers import load_config_with_secrets
 from dom.cli.contest.render import render_apply_warnings
+from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.contest import apply_contests_op
-from dom.utils.cli import add_global_options, cli_command
 
 
 @add_global_options

--- a/dom/cli/contest/helpers.py
+++ b/dom/cli/contest/helpers.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from dom.cli._helpers import load_with_secrets
+from dom.cli.helpers import load_with_secrets
 from dom.core.operations.contest import load_config_op
 
 

--- a/dom/cli/contest/inspect.py
+++ b/dom/cli/contest/inspect.py
@@ -8,8 +8,8 @@ import jmespath
 import typer
 
 from dom.cli.contest.helpers import load_config_with_secrets
+from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.validators import validate_file_path
-from dom.utils.cli import add_global_options, cli_command
 
 
 @add_global_options

--- a/dom/cli/contest/plan.py
+++ b/dom/cli/contest/plan.py
@@ -6,10 +6,10 @@ import typer
 
 from dom.cli.contest.helpers import load_config_with_secrets
 from dom.cli.contest.render import render_planned_changes
+from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.contest import plan_contest_changes_op
-from dom.utils.cli import add_global_options, cli_command
 
 
 @add_global_options

--- a/dom/cli/contest/render.py
+++ b/dom/cli/contest/render.py
@@ -9,7 +9,17 @@ from typing import Any
 
 from dom import ui
 from dom.core.services.contest.apply import ContestApplyResult
-from dom.core.services.contest.changes import ChangeType
+from dom.core.services.contest.changes import ChangeType, ContestChangeSet
+
+
+def format_contest_change_summary(change_set: ContestChangeSet) -> str:
+    """Render a :class:`ContestChangeSet` as a Rich-markup-decorated line."""
+    change_type, shortname, parts = change_set.summary_parts()
+    if change_type == ChangeType.CREATE:
+        return f"[green]CREATE[/green] contest '{shortname}'"
+    if not parts:
+        return f"[dim]NO CHANGES[/dim] for contest '{shortname}'"
+    return f"[yellow]UPDATE[/yellow] contest '{shortname}': {', '.join(parts)}"
 
 
 def render_planned_changes(changes: list[dict[str, Any]]) -> None:
@@ -33,7 +43,7 @@ def render_planned_changes(changes: list[dict[str, Any]]) -> None:
         if change_set.change_type == ChangeType.CREATE:
             any_creates = True
 
-        ui.info(f"  {change_set.summary()}")
+        ui.info(f"  {format_contest_change_summary(change_set)}")
 
         if change_set.field_changes:
             any_field_changes = True

--- a/dom/cli/contest/verify_problemset.py
+++ b/dom/cli/contest/verify_problemset.py
@@ -4,10 +4,11 @@ from pathlib import Path
 
 import typer
 
+from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.validators import validate_contest_name, validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.contest import verify_problemset_op
-from dom.utils.cli import add_global_options, cli_command, get_secrets_manager
+from dom.utils.cli import get_secrets_manager
 
 
 @add_global_options

--- a/dom/cli/decorators.py
+++ b/dom/cli/decorators.py
@@ -1,0 +1,72 @@
+"""Decorators applied to every Typer CLI command.
+
+These belong to the CLI layer (presentation): they configure logging,
+catch errors, and render user-visible messages via ``dom.ui``. They
+were previously in ``dom.utils.cli`` — moved here so utilities stay
+free of UI concerns.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from functools import wraps
+from typing import TypeVar
+
+import typer
+
+from dom import ui
+from dom.exceptions import DomJudgeCliError
+from dom.logging_config import get_logger, setup_logging
+from dom.utils.cli import ensure_dom_directory
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+def add_global_options(func: Callable[..., T]) -> Callable[..., T]:
+    """Adds ``--verbose`` / ``--no-color`` to a command and configures logging."""
+
+    @wraps(func)
+    def wrapper(
+        *args,
+        verbose: bool = typer.Option(False, "--verbose", help="Enable verbose logging output"),
+        no_color: bool = typer.Option(False, "--no-color", help="Disable colored output"),
+        **kwargs,
+    ) -> T:
+        log_dir = ensure_dom_directory()
+        log_file = log_dir / "domjudge-cli.log"
+        log_level = "DEBUG" if verbose else "INFO"
+        setup_logging(
+            level=log_level,
+            log_file=log_file,
+            enable_rich=not no_color,
+            console_output=verbose,
+        )
+        return func(*args, verbose=verbose, no_color=no_color, **kwargs)
+
+    return wrapper
+
+
+def cli_command(func: Callable[..., T]) -> Callable[..., T]:
+    """Standard error handling and exit-code mapping for CLI commands."""
+
+    @wraps(func)
+    def wrapper(*args, **kwargs) -> T:
+        try:
+            return func(*args, **kwargs)
+        except DomJudgeCliError as e:
+            logger.error(f"Command failed: {e}")
+            raise typer.Exit(code=1) from e
+        except KeyboardInterrupt:
+            logger.info("Command interrupted by user")
+            ui.blank()
+            ui.warn("** Operation cancelled by user")
+            raise typer.Exit(code=130) from None
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}", exc_info=True)
+            ui.error(f"x Unexpected error: {e}")
+            ui.hint("Check logs at .dom/domjudge-cli.log for details")
+            raise typer.Exit(code=1) from e
+
+    return wrapper

--- a/dom/cli/helpers.py
+++ b/dom/cli/helpers.py
@@ -10,6 +10,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import TypeVar
 
+from dom import ui
 from dom.core.operations import Context, run
 from dom.core.operations.framework import Operation
 from dom.types.secrets import SecretsProvider
@@ -40,3 +41,21 @@ def load_with_secrets(
             "load operations must be single-step and produce a config object"
         )
     return config, secrets
+
+
+def ask_override_if_exists(output_file: Path) -> bool:
+    """Prompt the user to confirm overriding ``output_file`` if it exists.
+
+    Returns ``True`` if the caller should proceed (file absent, or user
+    confirmed override), ``False`` if the caller should skip.
+    """
+    if not output_file.exists():
+        return True
+    override = ui.ask_bool(
+        f"File '{output_file}' exists. Do you want to override it?",
+        default=False,
+    )
+    if not override:
+        ui.warn("Skipping problem initialization.")
+        return False
+    return True

--- a/dom/cli/infrastructure/apply.py
+++ b/dom/cli/infrastructure/apply.py
@@ -4,11 +4,11 @@ from pathlib import Path
 
 import typer
 
+from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.infrastructure.helpers import load_infra_config_with_secrets
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.infrastructure import apply_infrastructure_op
-from dom.utils.cli import add_global_options, cli_command
 
 
 @add_global_options

--- a/dom/cli/infrastructure/destroy.py
+++ b/dom/cli/infrastructure/destroy.py
@@ -3,9 +3,10 @@
 import typer
 
 from dom import ui
+from dom.cli.decorators import add_global_options, cli_command
 from dom.core.operations import Context, run
 from dom.core.operations.infrastructure import destroy_infrastructure_op
-from dom.utils.cli import add_global_options, cli_command, get_secrets_manager
+from dom.utils.cli import get_secrets_manager
 
 
 @add_global_options

--- a/dom/cli/infrastructure/helpers.py
+++ b/dom/cli/infrastructure/helpers.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from dom.cli._helpers import load_with_secrets
+from dom.cli.helpers import load_with_secrets
 from dom.core.operations.infrastructure import load_infra_config_op
 
 

--- a/dom/cli/infrastructure/plan.py
+++ b/dom/cli/infrastructure/plan.py
@@ -4,12 +4,12 @@ from pathlib import Path
 
 import typer
 
+from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.infrastructure.helpers import load_infra_config_with_secrets
 from dom.cli.infrastructure.render import render_planned_changes
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.infrastructure import plan_infra_changes_op
-from dom.utils.cli import add_global_options, cli_command
 
 
 @add_global_options

--- a/dom/cli/infrastructure/render.py
+++ b/dom/cli/infrastructure/render.py
@@ -1,4 +1,8 @@
-"""CLI-side renderers for infrastructure output."""
+"""CLI-side renderers for infrastructure output.
+
+The service layer returns a plain :class:`InfraChangeSet`; this module
+owns the Rich markup that turns it into a coloured CLI line.
+"""
 
 import json
 
@@ -6,8 +10,38 @@ from rich import box
 from rich.table import Table
 
 from dom import ui
-from dom.core.services.infra.state import InfraChangeSet
+from dom.core.services.infra.state import InfraChangeSet, InfraChangeType
 from dom.types.infra import InfrastructureStatus, ServiceStatus
+
+
+def format_change_summary(change_set: InfraChangeSet) -> str:
+    """Render an :class:`InfraChangeSet` as a Rich-markup-decorated line."""
+    ct = change_set.change_type
+
+    if ct is InfraChangeType.CREATE:
+        return "[green]CREATE[/green] new infrastructure"
+    if ct is InfraChangeType.NO_CHANGE:
+        return "[dim]NO CHANGES[/dim] to infrastructure"
+    if ct is InfraChangeType.SCALE_JUDGES:
+        direction = (
+            "[green]SCALE UP[/green]"
+            if change_set.judge_diff > 0
+            else "[yellow]SCALE DOWN[/yellow]"
+        )
+        old = change_set.old_config.judges if change_set.old_config else "?"
+        return f"{direction} judgehosts: {old} → {change_set.new_config.judges} (safe live change)"
+    if ct is InfraChangeType.PORT_CHANGE:
+        old = change_set.old_config.port if change_set.old_config else "?"
+        return (
+            f"[red]PORT CHANGE[/red]: {old} → {change_set.new_config.port} "
+            "[bold](requires restart)[/bold]"
+        )
+    if ct is InfraChangeType.PASSWORD_CHANGE:
+        return "[yellow]PASSWORD CHANGE[/yellow] [bold](requires restart)[/bold]"
+    if ct is InfraChangeType.FULL_RESTART:
+        return "[red]MULTIPLE CHANGES[/red] [bold](requires full restart)[/bold]"
+
+    raise ValueError(f"Unknown infra change type: {ct}")
 
 
 def render_planned_changes(change_set: InfraChangeSet | None) -> None:
@@ -20,7 +54,7 @@ def render_planned_changes(change_set: InfraChangeSet | None) -> None:
     ui.blank()
     ui.write("Planned Infrastructure Changes:", style="bold")
     ui.blank()
-    ui.info(f"  {change_set.summary()}")
+    ui.info(f"  {format_change_summary(change_set)}")
     ui.blank()
 
     if change_set.requires_restart:
@@ -116,6 +150,4 @@ def render_status(status: InfrastructureStatus, *, json_output: bool = False) ->
         ui.success("[OK] Ready to accept commands")
     else:
         ui.blank()
-        ui.warn(
-            "[**] Some services are not healthy. " "Infrastructure may not be fully operational."
-        )
+        ui.warn("[**] Some services are not healthy. Infrastructure may not be fully operational.")

--- a/dom/cli/infrastructure/status.py
+++ b/dom/cli/infrastructure/status.py
@@ -4,11 +4,12 @@ from pathlib import Path
 
 import typer
 
+from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.infrastructure.render import render_status
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.infrastructure import check_infra_status_op
-from dom.utils.cli import add_global_options, cli_command, get_secrets_manager
+from dom.utils.cli import get_secrets_manager
 
 
 @add_global_options

--- a/dom/cli/init/command.py
+++ b/dom/cli/init/command.py
@@ -3,9 +3,9 @@
 import typer
 
 from dom import ui
+from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.init.wizard import run_wizard
 from dom.logging_config import get_logger
-from dom.utils.cli import add_global_options, cli_command
 
 logger = get_logger(__name__)
 

--- a/dom/cli/init/wizard/problems.py
+++ b/dom/cli/init/wizard/problems.py
@@ -5,8 +5,8 @@ from jinja2 import Template
 from rich.table import Table
 
 from dom import ui
+from dom.cli.helpers import ask_override_if_exists
 from dom.templates.init import problems_template
-from dom.utils.cli import ask_override_if_exists
 from dom.utils.color import get_hex_color
 
 

--- a/dom/cli/runner.py
+++ b/dom/cli/runner.py
@@ -1,0 +1,97 @@
+"""Rich-flavored renderer for the operations framework.
+
+The framework is presentation-agnostic; this module wires its events
+to ``dom.ui`` (markup, blank lines, success/error styling) and to a
+``rich.Progress`` widget for multi-step operations.
+
+Importing this module installs the renderer as the framework's default,
+so every subsequent ``dom.core.operations.run(...)`` call picks it up
+without having to thread a ``renderer=`` argument through.
+"""
+
+from __future__ import annotations
+
+from rich.progress import (
+    BarColumn,
+    MofNCompleteColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
+
+from dom import ui
+from dom.core.operations.framework import (
+    Renderer,
+    Step,
+    StepProgress,
+    set_default_renderer,
+)
+from dom.ui import console
+
+
+class _NullProgress:
+    def step(self, step_label: str, index: int) -> None:  # noqa: ARG002
+        return None
+
+    def finish(self) -> None:
+        return None
+
+
+class _RichProgress:
+    def __init__(self, label: str, total: int) -> None:
+        self._label = label
+        self._progress = Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(bar_width=30),
+            MofNCompleteColumn(),
+            TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
+            TimeElapsedColumn(),
+            console=console,
+        )
+        self._progress.start()
+        self._task = self._progress.add_task(label, total=total)
+
+    def step(self, step_label: str, index: int) -> None:
+        self._progress.update(self._task, description=f"{self._label} - {step_label}")
+        if index > 1:
+            self._progress.advance(self._task)
+
+    def finish(self) -> None:
+        self._progress.advance(self._task)
+        self._progress.update(self._task, description=self._label)
+        self._progress.stop()
+
+
+class RichRenderer:
+    """Renders operation events with ``dom.ui`` markup and Rich progress."""
+
+    def dry_run(self, label: str, steps: list[Step] | None) -> None:
+        ui.write(f"[yellow]* Dry run:[/yellow] {label}")
+        if steps:
+            ui.warn("  Steps that would be executed:")
+            for i, step in enumerate(steps, 1):
+                ui.warn(f"    {i}. {step.label}")
+
+    def plan(self, steps: list[Step]) -> None:
+        ui.write(f"Execution plan ({len(steps)} steps):", style="cyan")
+        for i, step in enumerate(steps, 1):
+            ui.write(f"  {i}. {step.label}", style="cyan")
+        ui.blank()
+
+    def steps_started(self, label: str, total: int, *, show_progress: bool) -> StepProgress:
+        if not show_progress or total == 0:
+            return _NullProgress()
+        return _RichProgress(label, total)
+
+    def success(self, label: str, message: str) -> None:
+        ui.write(f"[green]+[/green] {message or label}")
+
+    def failure(self, label: str, exc: Exception) -> None:
+        ui.write(f"[red]x[/red] {label}")
+        ui.write(f"[red]  Error:[/red] {exc}")
+
+
+_renderer: Renderer = RichRenderer()
+set_default_renderer(_renderer)

--- a/dom/core/operations/__init__.py
+++ b/dom/core/operations/__init__.py
@@ -6,15 +6,28 @@ for concrete operations.
 """
 
 from . import contest, infrastructure
-from .framework import Context, Operation, Step, Steps, operation, run
+from .framework import (
+    Context,
+    Operation,
+    Renderer,
+    Step,
+    StepProgress,
+    Steps,
+    operation,
+    run,
+    set_default_renderer,
+)
 
 __all__ = [
     "Context",
     "Operation",
+    "Renderer",
     "Step",
+    "StepProgress",
     "Steps",
     "contest",
     "infrastructure",
     "operation",
     "run",
+    "set_default_renderer",
 ]

--- a/dom/core/operations/framework.py
+++ b/dom/core/operations/framework.py
@@ -4,7 +4,7 @@ An *operation* is a named, runnable unit of work. There are two shapes:
 
 * **Multi-step** — function returns :class:`Steps` (a list of labeled
   steps with an optional final summary). The runner executes each step
-  with progress UI.
+  via the configured :class:`Renderer`.
 * **Single-step** — function returns the operation's result value
   directly. A ``summary=`` callback on the decorator can format the
   success line.
@@ -12,6 +12,11 @@ An *operation* is a named, runnable unit of work. There are two shapes:
 Use ``@operation(label, summary=...)`` to declare. Calling the decorated
 function with its non-context arguments returns an :class:`Operation`
 bound to those arguments; pass it to :func:`run` with a :class:`Context`.
+
+The framework is presentation-agnostic: it emits events via a
+:class:`Renderer` and never imports ``dom.ui`` or ``rich``. The CLI
+layer supplies a Rich-flavored renderer; tests rely on the default
+:class:`_PlainRenderer` which writes plain text to stdout.
 
 Example (multi-step)::
 
@@ -25,16 +30,9 @@ Example (multi-step)::
 
     run(apply_infra(config), Context(secrets=mgr))
 
-Example (single-step)::
-
-    @operation("Load configuration", summary=lambda c: f"{len(c.contests)} contests")
-    def load_config_op(ctx: Context, path: Path | None) -> DomConfig:
-        return load_config(path, ctx.secrets)
-
-    config = run(load_config_op(path), Context(secrets=mgr))
-
-Errors propagate as exceptions. The runner logs and renders them, then
-raises ``typer.Exit(1)``. Dry-run mode prints labels without executing.
+Errors propagate as exceptions. The runner asks the renderer to display
+them, then raises ``typer.Exit(1)``. Dry-run mode emits labels via the
+renderer without executing.
 """
 
 from __future__ import annotations
@@ -42,22 +40,12 @@ from __future__ import annotations
 import functools
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Any, Generic, NoReturn, TypeVar, Union
+from typing import Any, Generic, NoReturn, Protocol, TypeVar, Union
 
 import typer
-from rich.progress import (
-    BarColumn,
-    MofNCompleteColumn,
-    Progress,
-    SpinnerColumn,
-    TextColumn,
-    TimeElapsedColumn,
-)
 
-from dom import ui
 from dom.logging_config import get_logger
 from dom.types.secrets import SecretsProvider
-from dom.ui import console
 
 logger = get_logger(__name__)
 
@@ -91,20 +79,11 @@ class Steps:
 
 @dataclass(frozen=True)
 class _Value(Generic[T]):
-    """Wrapper marking a single-step op's return value.
-
-    Internal to the framework — operations don't construct this directly.
-    Together with :class:`Steps`, it forms the discriminated ``Plan``
-    union the runner dispatches on, replacing the prior heuristic
-    isinstance-on-list classification.
-    """
+    """Wrapper marking a single-step op's return value."""
 
     value: T
 
 
-# A plan is what an operation function returns once normalized: either a
-# multi-step ``Steps`` or a wrapped single-step ``_Value``. Any other
-# return is wrapped as ``_Value`` at normalization time.
 Plan = Union[Steps, "_Value[T]"]
 
 
@@ -124,13 +103,7 @@ def operation(
     summary: Callable[[T], str] | None = None,
     show_progress: bool = True,
 ) -> Callable[[Callable[..., Any]], Callable[..., Operation[T]]]:
-    """Mark a function as an operation.
-
-    The decorated function takes ``(ctx: Context, *args, **kwargs)`` and
-    returns either a :class:`Steps` (multi-step) or any value (single-step,
-    auto-wrapped). Calling the decorated function with its non-context
-    arguments returns an :class:`Operation` bound to those arguments.
-    """
+    """Mark a function as an operation."""
 
     def decorator(fn: Callable[..., Any]) -> Callable[..., Operation[T]]:
         @functools.wraps(fn)
@@ -150,12 +123,98 @@ def operation(
     return decorator
 
 
-def run(op: Operation[T], ctx: Context) -> T | None:
-    """Execute an operation with progress UI, dry-run support, error handling.
+# ---------------------------------------------------------------- renderer
 
-    Returns the operation's result value (or ``None`` for multi-step ops).
-    On failure, logs and renders the error, then raises ``typer.Exit(1)``.
+
+class StepProgress(Protocol):
+    """Per-execution handle returned by :meth:`Renderer.steps_started`.
+
+    The runner calls :meth:`step` once per step and :meth:`finish` once
+    at the end (in a ``try``/``finally``). Plain renderers can ignore
+    these calls; Rich renderers drive a ``rich.Progress`` widget.
     """
+
+    def step(self, step_label: str, index: int) -> None: ...
+    def finish(self) -> None: ...
+
+
+class Renderer(Protocol):
+    """Sink for operation lifecycle events."""
+
+    def dry_run(self, label: str, steps: list[Step] | None) -> None: ...
+    def plan(self, steps: list[Step]) -> None: ...
+    def steps_started(self, label: str, total: int, *, show_progress: bool) -> StepProgress: ...
+    def success(self, label: str, message: str) -> None: ...
+    def failure(self, label: str, exc: Exception) -> None: ...
+
+
+class _PlainStepProgress:
+    def step(self, step_label: str, index: int) -> None:  # noqa: ARG002
+        return None
+
+    def finish(self) -> None:
+        return None
+
+
+class _PlainRenderer:
+    """Default renderer: plain stdout, no Rich, no ``dom.ui``.
+
+    Used in tests and as a safe fallback when the CLI hasn't installed a
+    fancier renderer. Output uses ASCII glyphs only.
+    """
+
+    def dry_run(self, label: str, steps: list[Step] | None) -> None:
+        print(f"* Dry run: {label}")
+        if steps:
+            print("  Steps that would be executed:")
+            for i, step in enumerate(steps, 1):
+                print(f"    {i}. {step.label}")
+
+    def plan(self, steps: list[Step]) -> None:
+        print(f"Execution plan ({len(steps)} steps):")
+        for i, step in enumerate(steps, 1):
+            print(f"  {i}. {step.label}")
+        print()
+
+    def steps_started(
+        self,
+        label: str,  # noqa: ARG002
+        total: int,  # noqa: ARG002
+        *,
+        show_progress: bool,  # noqa: ARG002
+    ) -> StepProgress:
+        return _PlainStepProgress()
+
+    def success(self, label: str, message: str) -> None:
+        print(f"+ {message or label}")
+
+    def failure(self, label: str, exc: Exception) -> None:
+        print(f"x {label}")
+        print(f"  Error: {exc}")
+
+
+_default_renderer: Renderer = _PlainRenderer()
+
+
+def set_default_renderer(renderer: Renderer) -> None:
+    """Install a process-wide default renderer for :func:`run`.
+
+    Called once during CLI startup to swap in the Rich-flavored renderer.
+    Tests leave the default :class:`_PlainRenderer` in place.
+    """
+    global _default_renderer  # noqa: PLW0603
+    _default_renderer = renderer
+
+
+def run(
+    op: Operation[T],
+    ctx: Context,
+    *,
+    renderer: Renderer | None = None,
+) -> T | None:
+    """Execute an operation. Returns the result value (or ``None`` for multi-step)."""
+    r = renderer or _default_renderer
+
     logger.info(
         f"Executing operation: {op.label}",
         extra={"operation": op.label, "dry_run": ctx.dry_run},
@@ -164,25 +223,23 @@ def run(op: Operation[T], ctx: Context) -> T | None:
     try:
         plan: Plan[T] = op.build(ctx)
     except Exception as exc:
-        _fail(op.label, exc)
+        _fail(r, op.label, exc)
 
     if ctx.dry_run:
-        _print_dry_run(op.label, plan.steps if isinstance(plan, Steps) else None)
+        r.dry_run(op.label, plan.steps if isinstance(plan, Steps) else None)
         return None
 
     if isinstance(plan, Steps):
         try:
-            _execute_steps(
-                op.label, plan.steps, show_progress=op.show_progress, verbose=ctx.verbose
-            )
+            _execute_steps(r, op.label, plan.steps, op.show_progress, ctx.verbose)
         except Exception as exc:
-            _fail(op.label, exc)
-        _print_success(op.label, plan.summary)
+            _fail(r, op.label, exc)
+        r.success(op.label, plan.summary)
         logger.info(f"Operation completed: {op.label}", extra={"operation": op.label})
         return None
 
     message = _resolve_summary(op, plan.value)
-    _print_success(op.label, message)
+    r.success(op.label, message)
     logger.info(f"Operation completed: {op.label}", extra={"operation": op.label})
     return plan.value
 
@@ -191,14 +248,6 @@ def run(op: Operation[T], ctx: Context) -> T | None:
 
 
 def _normalize(plan: Any) -> Plan[Any]:
-    """Wrap an operation function's return into the discriminated ``Plan``.
-
-    A :class:`Steps` is returned as-is; everything else (including
-    ``None`` and lists of any kind) is wrapped in ``_Value``. This
-    eliminates the prior ambiguity where a bare ``list[Step]`` was
-    inferred via ``all(isinstance(...))`` — multi-step ops must now
-    return :class:`Steps` explicitly.
-    """
     if isinstance(plan, Steps):
         return plan
     return _Value(plan)
@@ -214,51 +263,27 @@ def _resolve_summary(op: Operation[T], value: T) -> str:
         return ""
 
 
-def _execute_steps(label: str, steps: list[Step], *, show_progress: bool, verbose: bool) -> None:
-    if verbose:
-        ui.write(f"Execution plan ({len(steps)} steps):", style="cyan")
-        for i, step in enumerate(steps, 1):
-            ui.write(f"  {i}. {step.label}", style="cyan")
-        ui.blank()
+def _execute_steps(
+    renderer: Renderer,
+    label: str,
+    steps: list[Step],
+    show_progress: bool,
+    verbose: bool,
+) -> None:
+    if verbose and steps:
+        renderer.plan(steps)
 
-    if not show_progress or not steps:
-        for step in steps:
+    progress = renderer.steps_started(label, len(steps), show_progress=show_progress)
+    try:
+        for i, step in enumerate(steps, 1):
+            progress.step(step.label, i)
             logger.debug(f"Step: {step.label}")
             step.fn()
-        return
-
-    with Progress(
-        SpinnerColumn(),
-        TextColumn("[progress.description]{task.description}"),
-        BarColumn(bar_width=30),
-        MofNCompleteColumn(),
-        TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
-        TimeElapsedColumn(),
-        console=console,
-    ) as progress:
-        task = progress.add_task(label, total=len(steps))
-        for step in steps:
-            progress.update(task, description=f"{label} - {step.label}")
-            logger.debug(f"Step: {step.label}")
-            step.fn()
-            progress.advance(task)
-        progress.update(task, description=label)
+    finally:
+        progress.finish()
 
 
-def _print_dry_run(label: str, steps: list[Step] | None) -> None:
-    ui.write(f"[yellow]* Dry run:[/yellow] {label}")
-    if steps:
-        ui.warn("  Steps that would be executed:")
-        for i, step in enumerate(steps, 1):
-            ui.warn(f"    {i}. {step.label}")
-
-
-def _print_success(label: str, message: str) -> None:
-    ui.write(f"[green]+[/green] {message or label}")
-
-
-def _fail(label: str, exc: Exception) -> NoReturn:
+def _fail(renderer: Renderer, label: str, exc: Exception) -> NoReturn:
     logger.error(f"Operation failed: {label}", exc_info=exc, extra={"operation": label})
-    ui.write(f"[red]x[/red] {label}")
-    ui.write(f"[red]  Error:[/red] {exc}")
+    renderer.failure(label, exc)
     raise typer.Exit(code=1)

--- a/dom/core/services/contest/changes.py
+++ b/dom/core/services/contest/changes.py
@@ -74,19 +74,21 @@ class ContestChangeSet:
             or any(rc.has_changes for rc in self.resource_changes)
         )
 
-    def summary(self) -> str:
-        """Get a human-readable summary of changes."""
-        if self.change_type == ChangeType.CREATE:
-            return f"[green]CREATE[/green] contest '{self.contest_shortname}'"
+    def summary_parts(self) -> tuple[ChangeType, str, list[str]]:
+        """Return the raw pieces a renderer needs.
 
-        if not self.has_changes:
-            return f"[dim]NO CHANGES[/dim] for contest '{self.contest_shortname}'"
+        Returns a ``(change_type, contest_shortname, parts)`` triple
+        where ``parts`` describes what's changing — empty when there
+        are no changes. Presentation (markup, prefixes) is the caller's
+        responsibility.
+        """
+        if self.change_type == ChangeType.CREATE or not self.has_changes:
+            return self.change_type, self.contest_shortname, []
 
-        parts = []
+        parts: list[str] = []
         if self.field_changes:
             parts.append(f"{len(self.field_changes)} field(s)")
         for rc in self.resource_changes:
             if rc.has_changes:
                 parts.append(rc.resource_type)
-
-        return f"[yellow]UPDATE[/yellow] contest '{self.contest_shortname}': {', '.join(parts)}"
+        return self.change_type, self.contest_shortname, parts

--- a/dom/core/services/infra/state.py
+++ b/dom/core/services/infra/state.py
@@ -1,4 +1,10 @@
-"""Infrastructure state comparison and change detection."""
+"""Infrastructure state comparison and change detection.
+
+The comparator queries Docker as the source of truth for the currently
+deployed infrastructure and produces an :class:`InfraChangeSet`
+classifying the diff against the desired :class:`InfraConfig`. The CLI
+layer renders the change set; this module stays free of presentation.
+"""
 
 import re
 import subprocess  # nosec B404
@@ -37,17 +43,17 @@ def _run_docker(args: list[str], *, check: bool = False) -> subprocess.Completed
 class InfraChangeType(str, Enum):
     """Types of infrastructure changes."""
 
-    CREATE = "create"  # New infrastructure
-    SCALE_JUDGES = "scale_judges"  # Only judgehost count changed
-    PORT_CHANGE = "port_change"  # Port changed (requires restart)
-    PASSWORD_CHANGE = "password_change"  # nosec B105  # Password changed (requires restart)
-    FULL_RESTART = "full_restart"  # Multiple changes requiring full restart
-    NO_CHANGE = "no_change"  # No changes
+    CREATE = "create"
+    SCALE_JUDGES = "scale_judges"
+    PORT_CHANGE = "port_change"
+    PASSWORD_CHANGE = "password_change"  # nosec B105
+    FULL_RESTART = "full_restart"
+    NO_CHANGE = "no_change"
 
 
 @dataclass
 class InfraChangeSet:
-    """Represents detected infrastructure changes."""
+    """Detected infrastructure changes between deployed and desired state."""
 
     change_type: InfraChangeType
     old_config: InfraConfig | None
@@ -56,48 +62,17 @@ class InfraChangeSet:
 
     @property
     def is_safe_live_change(self) -> bool:
-        """Check if this change can be applied to running infrastructure safely."""
+        """Whether this change can be applied to running infrastructure safely."""
         return self.change_type in (InfraChangeType.SCALE_JUDGES, InfraChangeType.NO_CHANGE)
 
     @property
     def requires_restart(self) -> bool:
-        """Check if this change requires full infrastructure restart."""
+        """Whether this change requires a full infrastructure restart."""
         return self.change_type in (
             InfraChangeType.PORT_CHANGE,
             InfraChangeType.PASSWORD_CHANGE,
             InfraChangeType.FULL_RESTART,
         )
-
-    def summary(self) -> str:
-        """Render a markup-decorated summary line for the CLI to print."""
-        return _SUMMARY_RENDERERS[self.change_type](self)
-
-
-def _summary_scale(cs: "InfraChangeSet") -> str:
-    direction = "[green]SCALE UP[/green]" if cs.judge_diff > 0 else "[yellow]SCALE DOWN[/yellow]"
-    old = cs.old_config.judges if cs.old_config else "?"
-    return f"{direction} judgehosts: {old} → {cs.new_config.judges} " "(safe live change)"
-
-
-def _summary_port(cs: "InfraChangeSet") -> str:
-    old = cs.old_config.port if cs.old_config else "?"
-    return (
-        f"[red]PORT CHANGE[/red]: {old} → {cs.new_config.port} " "[bold](requires restart)[/bold]"
-    )
-
-
-_SUMMARY_RENDERERS: dict[InfraChangeType, Callable[["InfraChangeSet"], str]] = {
-    InfraChangeType.CREATE: lambda _cs: "[green]CREATE[/green] new infrastructure",
-    InfraChangeType.NO_CHANGE: lambda _cs: "[dim]NO CHANGES[/dim] to infrastructure",
-    InfraChangeType.SCALE_JUDGES: _summary_scale,
-    InfraChangeType.PORT_CHANGE: _summary_port,
-    InfraChangeType.PASSWORD_CHANGE: lambda _cs: (
-        "[yellow]PASSWORD CHANGE[/yellow] [bold](requires restart)[/bold]"
-    ),
-    InfraChangeType.FULL_RESTART: lambda _cs: (
-        "[red]MULTIPLE CHANGES[/red] [bold](requires full restart)[/bold]"
-    ),
-}
 
 
 # Each entry: which combination of changed fields maps to which change type.
@@ -125,19 +100,14 @@ def _detect_changed_fields(old: InfraConfig, new: InfraConfig) -> frozenset[str]
 
 
 class InfraStateComparator:
-    """
-    Service for comparing infrastructure state to detect safe vs unsafe changes.
+    """Compare desired :class:`InfraConfig` against running Docker state.
 
-    Uses Docker as the single source of truth - no state files needed!
-    Queries running containers directly to determine current infrastructure state.
-
-    This enables intelligent infrastructure updates:
-    - Safe: Scaling judgehost count (hot swap)
-    - Unsafe: Port changes, password changes (require restart)
+    Uses Docker as the single source of truth — no state files needed.
+    Distinguishes safe live changes (judgehost scaling) from unsafe ones
+    (port / password changes) so callers can warn before destructive ops.
     """
 
     def __init__(self):
-        """Initialize infrastructure state comparator."""
         self.container_prefix = get_container_prefix()
 
     def compare_infrastructure(self, new_config: InfraConfig) -> InfraChangeSet:

--- a/dom/infrastructure/docker/__init__.py
+++ b/dom/infrastructure/docker/__init__.py
@@ -1,3 +1,13 @@
-from .containers import DockerClient
+from .containers import (
+    DockerClient,
+    DockerComposeManager,
+    DockerCredentialManager,
+    DockerHealthChecker,
+)
 
-__all__ = ["DockerClient"]
+__all__ = [
+    "DockerClient",
+    "DockerComposeManager",
+    "DockerCredentialManager",
+    "DockerHealthChecker",
+]

--- a/dom/infrastructure/docker/containers.py
+++ b/dom/infrastructure/docker/containers.py
@@ -1,8 +1,20 @@
 """Docker container management for DOMjudge infrastructure.
 
-This module provides a DockerClient class to manage Docker containers for DOMjudge,
-including starting services, checking health, and managing passwords.
+The Docker concerns are split by responsibility:
+
+* :class:`_DockerCli` — validates docker is reachable, holds the base
+  command and the per-project container prefix.
+* :class:`DockerComposeManager` — service lifecycle via ``docker compose``.
+* :class:`DockerHealthChecker` — container health polling.
+* :class:`DockerCredentialManager` — password fetch / update flows.
+
+:class:`DockerClient` is a thin facade composed of the above. It
+preserves the previous flat API so existing callers don't need to
+change; new code can depend on the smaller subclients directly when
+that's clearer (easier to mock in isolation).
 """
+
+from __future__ import annotations
 
 import re
 import subprocess  # nosec B404
@@ -18,39 +30,26 @@ from dom.utils.cli import get_container_prefix
 logger = get_logger(__name__)
 
 
-class DockerClient:
-    """
-    Docker client for managing containers and services.
+class _DockerCli:
+    """Probes the docker CLI on construction and holds the base command + prefix."""
 
-    Encapsulates Docker command execution with proper error handling and logging.
-    """
+    def __init__(self) -> None:
+        self._cmd = self._probe()
+        self.prefix = get_container_prefix()
+        logger.info(f"Docker client initialized successfully with prefix '{self.prefix}'")
 
-    def __init__(self):
-        """
-        Initialize Docker client.
+    @property
+    def cmd(self) -> list[str]:
+        return list(self._cmd)
 
-        Raises:
-            DockerError: If Docker is not accessible
-        """
-        self._cmd = self._initialize_docker_cmd()
-        self._container_prefix = get_container_prefix()
-        logger.info(
-            f"Docker client initialized successfully with prefix '{self._container_prefix}'"
-        )
-
-    def _initialize_docker_cmd(self) -> list[str]:
-        """
-        Initialize and validate Docker command.
-
-        Returns:
-            List containing the docker command
-
-        Raises:
-            DockerError: If docker is not accessible
-        """
+    @staticmethod
+    def _probe() -> list[str]:
         try:
             subprocess.run(  # nosec B603 B607
-                ["docker", "info"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=True
+                ["docker", "info"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=True,
             )
             logger.debug("Docker is accessible")
             return ["docker"]
@@ -65,20 +64,17 @@ class DockerClient:
                 "  3. Check if Docker daemon is running: 'sudo systemctl status docker'"
             ) from None
 
+
+class DockerComposeManager:
+    """Start and stop services via ``docker compose``."""
+
+    def __init__(self, cli: _DockerCli) -> None:
+        self._cli = cli
+
     def start_services(self, services: list[str], compose_file: Path) -> None:
-        """
-        Start Docker services using docker compose.
-
-        Args:
-            services: List of service names to start
-            compose_file: Path to docker-compose.yml file
-
-        Raises:
-            DockerError: If services fail to start
-        """
         logger.info(f"Starting services: {', '.join(services)}")
         cmd = [
-            *self._cmd,
+            *self._cli.cmd,
             "compose",
             "-f",
             str(compose_file),
@@ -87,7 +83,6 @@ class DockerClient:
             "--remove-orphans",
             *services,
         ]
-
         try:
             subprocess.run(cmd, check=True, capture_output=True, text=True)  # nosec B603
             logger.info(f"Successfully started services: {', '.join(services)}")
@@ -98,27 +93,15 @@ class DockerClient:
             )
             raise DockerError(f"Failed to start services: {e}") from e
 
-    def stop_all_services(self, compose_file: Path, remove_volumes: bool = False) -> None:
-        """
-        Stop all Docker services.
-
-        Args:
-            compose_file: Path to docker-compose.yml file
-            remove_volumes: Whether to remove volumes (WARNING: deletes all data)
-
-        Raises:
-            DockerError: If services fail to stop
-        """
+    def stop_all(self, compose_file: Path, remove_volumes: bool = False) -> None:
         logger.info("Stopping all services")
-        cmd = [*self._cmd, "compose", "-f", str(compose_file), "down"]
-
+        cmd = [*self._cli.cmd, "compose", "-f", str(compose_file), "down"]
         if remove_volumes:
             cmd.append("-v")
             logger.warning(
                 "Removing volumes - all contest data will be PERMANENTLY DELETED",
                 extra={"remove_volumes": True},
             )
-
         try:
             subprocess.run(cmd, check=True, capture_output=True, text=True)  # nosec B603
             logger.info("Successfully stopped all services")
@@ -126,26 +109,29 @@ class DockerClient:
             logger.error(f"Failed to stop services: {e}", extra={"returncode": e.returncode})
             raise DockerError(f"Failed to stop services: {e}") from e
 
+
+class DockerHealthChecker:
+    """Poll a container's health status until ready or timeout."""
+
+    def __init__(self, cli: _DockerCli) -> None:
+        self._cli = cli
+
     def wait_for_container_healthy(
         self, container_name: str, timeout: int = HEALTH_CHECK_TIMEOUT
     ) -> None:
-        """
-        Wait for a container to become healthy.
-
-        Args:
-            container_name: Name of the container to wait for (with prefix)
-            timeout: Maximum time to wait in seconds
-
-        Raises:
-            DockerError: If container becomes unhealthy or times out
-        """
         logger.info(f"Waiting for container '{container_name}' to become healthy...")
         start_time = time.time()
 
         while True:
-            cmd = [*self._cmd, "inspect", "--format={{.State.Health.Status}}", container_name]
-            result = subprocess.run(cmd, capture_output=True, text=True, check=False)  # nosec B603
-
+            cmd = [
+                *self._cli.cmd,
+                "inspect",
+                "--format={{.State.Health.Status}}",
+                container_name,
+            ]
+            result = subprocess.run(  # nosec B603
+                cmd, capture_output=True, text=True, check=False
+            )
             status = result.stdout.strip()
             if status == "healthy":
                 elapsed = time.time() - start_time
@@ -154,7 +140,7 @@ class DockerClient:
                     extra={"container": container_name, "elapsed_seconds": elapsed},
                 )
                 return
-            elif status == "unhealthy":
+            if status == "unhealthy":
                 logger.error(f"Container '{container_name}' became unhealthy")
                 raise DockerError(f"Container '{container_name}' became unhealthy!")
 
@@ -169,153 +155,96 @@ class DockerClient:
 
             time.sleep(HEALTH_CHECK_INTERVAL)
 
+
+class DockerCredentialManager:
+    """Fetch and rotate DOMjudge credentials via ``docker exec``."""
+
+    _JUDGEDAEMON_RE = re.compile(r"^\S+\s+\S+\s+\S+\s+(\S+)$", re.MULTILINE)
+    _ADMIN_INIT_RE = re.compile(r"^\S+$", re.MULTILINE)
+
+    def __init__(self, cli: _DockerCli) -> None:
+        self._cli = cli
+
     def fetch_judgedaemon_password(self) -> str:
-        """
-        Fetch the judgedaemon password from the domserver container.
-
-        Returns:
-            The judgedaemon password
-
-        Raises:
-            DockerError: If password cannot be fetched or parsed
-        """
         logger.info("Fetching judgedaemon password from domserver")
-        cmd = [
-            *self._cmd,
-            "exec",
-            ContainerNames.DOMSERVER.with_prefix(self._container_prefix),
-            "cat",
+        output = self._exec_in_domserver(
             "/opt/domjudge/domserver/etc/restapi.secret",
-        ]
-
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True)  # nosec B603
-
-            pattern = re.compile(r"^\S+\s+\S+\s+\S+\s+(\S+)$", re.MULTILINE)
-            match = pattern.search(result.stdout.strip())
-            if not match:
-                logger.error("Failed to parse judgedaemon password from output")
-                raise DockerError("Failed to parse judgedaemon password from output")
-
-            logger.debug("Successfully fetched judgedaemon password")
-            return match.group(1)
-        except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to fetch judgedaemon password: {e}")
-            raise DockerError(f"Failed to fetch judgedaemon password: {e}") from e
+            error_msg="Failed to fetch judgedaemon password",
+        )
+        match = self._JUDGEDAEMON_RE.search(output)
+        if not match:
+            logger.error("Failed to parse judgedaemon password from output")
+            raise DockerError("Failed to parse judgedaemon password from output")
+        logger.debug("Successfully fetched judgedaemon password")
+        return match.group(1)
 
     def fetch_admin_init_password(self) -> str:
-        """
-        Fetch the initial admin password from the domserver container.
-
-        Returns:
-            The initial admin password
-
-        Raises:
-            DockerError: If password cannot be fetched or parsed
-        """
         logger.info("Fetching initial admin password from domserver")
-        cmd = [
-            *self._cmd,
-            "exec",
-            ContainerNames.DOMSERVER.with_prefix(self._container_prefix),
-            "cat",
+        output = self._exec_in_domserver(
             "/opt/domjudge/domserver/etc/initial_admin_password.secret",
-        ]
-
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, check=True)  # nosec B603
-
-            pattern = re.compile(r"^\S+$", re.MULTILINE)
-            match = pattern.search(result.stdout.strip())
-            if not match:
-                logger.error("Failed to parse admin initial password from output")
-                raise DockerError("Failed to parse admin initial password from output")
-
-            logger.debug("Successfully fetched initial admin password")
-            return match.group(0)
-        except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to fetch admin initial password: {e}")
-            raise DockerError(f"Failed to fetch admin initial password: {e}") from e
+            error_msg="Failed to fetch admin initial password",
+        )
+        match = self._ADMIN_INIT_RE.search(output)
+        if not match:
+            logger.error("Failed to parse admin initial password from output")
+            raise DockerError("Failed to parse admin initial password from output")
+        logger.debug("Successfully fetched initial admin password")
+        return match.group(0)
 
     def update_admin_password(self, new_password: str, db_user: str, db_password: str) -> None:
-        """
-        Update admin password in the database using docker exec.
-
-        This method uses docker exec to connect to the database from within the mysql-client
-        container, which is more reliable than direct host connections.
-
-        Args:
-            new_password: New admin password (will be bcrypt hashed)
-            db_user: Database user
-            db_password: Database password
-
-        Raises:
-            DockerError: If password update fails or database connection fails
-        """
-        hashed_password = generate_bcrypt_password(new_password)
-
-        # Validate the hash format to ensure it's a valid bcrypt hash
-        if not hashed_password.startswith("$2") or len(hashed_password) != 60:
+        hashed = generate_bcrypt_password(new_password)
+        if not hashed.startswith("$2") or len(hashed) != 60:
             logger.error("Invalid bcrypt hash format detected")
             raise DockerError("Generated bcrypt hash has unexpected format")
 
         logger.info("Updating admin password in database")
+        self._update_admin_password_via_docker(hashed, db_user, db_password)
 
-        # Use docker exec method directly since it's more reliable
-        # The mysql-client container is already running and connected to the same network
-        self._update_admin_password_via_docker(hashed_password, db_user, db_password)
+    def _exec_in_domserver(self, path: str, *, error_msg: str) -> str:
+        cmd = [
+            *self._cli.cmd,
+            "exec",
+            ContainerNames.DOMSERVER.with_prefix(self._cli.prefix),
+            "cat",
+            path,
+        ]
+        try:
+            result = subprocess.run(  # nosec B603
+                cmd, capture_output=True, text=True, check=True
+            )
+            return result.stdout.strip()
+        except subprocess.CalledProcessError as e:
+            logger.error(f"{error_msg}: {e}")
+            raise DockerError(f"{error_msg}: {e}") from e
 
     def _update_admin_password_via_docker(
         self, hashed_password: str, db_user: str, db_password: str
     ) -> None:
-        """
-        Update admin password via docker exec as fallback.
-
-        Uses parameterized query via mysql CLI with proper escaping for bcrypt hashes.
-        Bcrypt hashes contain $ characters that need special handling.
-
-        Args:
-            hashed_password: Bcrypt hashed password (contains $ characters)
-            db_user: Database user
-            db_password: Database password
-
-        Raises:
-            DockerError: If password update fails
-        """
         try:
-            # Escape the bcrypt hash properly:
-            # 1. Replace single quotes with doubled single quotes for SQL
-            # 2. Escape backslashes for MySQL string literals
+            # Escape the bcrypt hash for a MySQL string literal:
+            # backslashes first (so the next replace doesn't re-escape them), then quotes.
             escaped_password = hashed_password.replace("\\", "\\\\").replace("'", "\\'")
-
-            # Build SQL query with escaped password
-            sql_query = f"UPDATE domjudge.user SET password = '{escaped_password}' WHERE username = 'admin';"  # nosec B608
-
+            sql_query = (
+                f"UPDATE domjudge.user SET password = '{escaped_password}' "  # nosec B608
+                "WHERE username = 'admin';"
+            )
             cmd = [
-                *self._cmd,
+                *self._cli.cmd,
                 "exec",
                 "-e",
                 f"MYSQL_PWD={db_password}",
-                ContainerNames.MYSQL_CLIENT.with_prefix(self._container_prefix),
+                ContainerNames.MYSQL_CLIENT.with_prefix(self._cli.prefix),
                 "mysql",
                 "-h",
-                ContainerNames.MARIADB.with_prefix(self._container_prefix),
+                ContainerNames.MARIADB.with_prefix(self._cli.prefix),
                 "-u",
                 db_user,
                 "domjudge",
                 "--execute",
                 sql_query,
             ]
-
-            subprocess.run(
-                cmd,
-                capture_output=True,
-                check=True,
-                text=True,
-            )  # nosec B603
-
+            subprocess.run(cmd, capture_output=True, check=True, text=True)  # nosec B603
             logger.info("Admin password successfully updated via docker exec")
-
         except subprocess.CalledProcessError as e:
             logger.error(
                 f"Failed to update admin password via docker: {e}",
@@ -326,3 +255,52 @@ class DockerClient:
                 },
             )
             raise DockerError(f"Failed to update admin password: {e}") from e
+
+
+class DockerClient:
+    """Facade exposing the legacy flat Docker API, composed of focused subclients.
+
+    New code should prefer depending on a specific subclient (compose,
+    health, credentials) for clearer mocking and SRP. The facade is
+    retained so existing callers continue to work; it can be removed
+    once all call sites migrate.
+    """
+
+    def __init__(self) -> None:
+        self._cli = _DockerCli()
+        self.compose = DockerComposeManager(self._cli)
+        self.health = DockerHealthChecker(self._cli)
+        self.credentials = DockerCredentialManager(self._cli)
+
+    @property
+    def _cmd(self) -> list[str]:
+        return self._cli.cmd
+
+    # ------------------------------------------------------------------ compose
+    def start_services(self, services: list[str], compose_file: Path) -> None:
+        self.compose.start_services(services, compose_file)
+
+    def stop_all_services(self, compose_file: Path, remove_volumes: bool = False) -> None:
+        self.compose.stop_all(compose_file, remove_volumes=remove_volumes)
+
+    # ------------------------------------------------------------------ health
+    def wait_for_container_healthy(
+        self, container_name: str, timeout: int = HEALTH_CHECK_TIMEOUT
+    ) -> None:
+        self.health.wait_for_container_healthy(container_name, timeout)
+
+    # ------------------------------------------------------------------ credentials
+    def fetch_judgedaemon_password(self) -> str:
+        return self.credentials.fetch_judgedaemon_password()
+
+    def fetch_admin_init_password(self) -> str:
+        return self.credentials.fetch_admin_init_password()
+
+    def update_admin_password(self, new_password: str, db_user: str, db_password: str) -> None:
+        self.credentials.update_admin_password(new_password, db_user, db_password)
+
+    def _update_admin_password_via_docker(
+        self, hashed_password: str, db_user: str, db_password: str
+    ) -> None:
+        # Retained for tests that exercise the SQL-escaping logic directly.
+        self.credentials._update_admin_password_via_docker(hashed_password, db_user, db_password)

--- a/dom/utils/cli.py
+++ b/dom/utils/cli.py
@@ -1,154 +1,41 @@
-from collections.abc import Callable
-from functools import wraps
+"""Cross-layer filesystem / project utilities.
+
+These helpers are *not* CLI-specific even though the module name says
+"cli". They're consumed by services and infrastructure (e.g.
+``get_container_prefix``) as well as the CLI. UI-bearing decorators and
+prompts live in :mod:`dom.cli.decorators` and :mod:`dom.cli.helpers`.
+"""
+
 from hashlib import sha256
 from pathlib import Path
-from typing import TypeVar
 
-import typer
-
-from dom import ui
-from dom.exceptions import DomJudgeCliError
 from dom.infrastructure.secrets.manager import SecretsManager
-from dom.logging_config import get_logger, setup_logging
+from dom.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-# Type variable for generic decorator
-T = TypeVar("T")
-
 
 def ensure_dom_directory() -> Path:
-    """
-    Ensure that the .dom directory exists in the current working directory.
-    Returns the absolute path to the .dom folder.
-    """
+    """Ensure ``.dom`` exists in the current working directory and return it."""
     dom_path = Path.cwd() / ".dom"
     dom_path.mkdir(exist_ok=True)
     return dom_path
 
 
 def get_container_prefix() -> str:
+    """Generate a unique container prefix derived from the current working directory.
+
+    Allows multiple DOMjudge instances to coexist on one host; the
+    prefix is a deterministic short hash of the absolute CWD path.
     """
-    Generate a unique container prefix based on the current working directory.
-
-    This allows multiple DOMjudge instances to run simultaneously from different
-    directories without naming collisions. The prefix is generated from a hash
-    of the absolute path to ensure it's deterministic and filesystem-safe.
-
-    Returns:
-        A container prefix like 'domjudge-abc123' based on the directory path
-
-    Example:
-        >>> # In /home/user/contest1:
-        >>> get_container_prefix()
-        'domjudge-a3f4b2'
-        >>> # In /home/user/contest2:
-        >>> get_container_prefix()
-        'domjudge-c7e891'
-    """
-    # Get absolute path of current working directory
     cwd = Path.cwd().resolve()
-
-    # Generate a short hash from the path (first 6 chars of SHA256)
     path_hash = sha256(str(cwd).encode()).hexdigest()[:6]
-
     return f"domjudge-{path_hash}"
 
 
 def get_secrets_manager() -> SecretsManager:
-    """
-    Get initialized secrets manager for the current project.
-
-    Returns:
-        Configured SecretsManager instance
-    """
+    """Return a ``SecretsManager`` rooted at the current project's ``.dom`` directory."""
     return SecretsManager(ensure_dom_directory())
-
-
-def add_global_options(func: Callable[..., T]) -> Callable[..., T]:
-    """
-    Decorator that adds global CLI options to any command function.
-
-    This decorator automatically adds the following global options:
-    - --verbose: Enable verbose logging output
-    - --no-color: Disable colored output
-
-    The options are added as parameters to the function, so they can be used
-    directly in the command implementation.
-
-    Usage:
-        @app.command()
-        @add_global_options
-        def my_command(arg: str, verbose: bool = False, no_color: bool = False):
-            # Command logic here
-            pass
-    """
-
-    @wraps(func)
-    def wrapper(
-        *args,
-        verbose: bool = typer.Option(False, "--verbose", help="Enable verbose logging output"),
-        no_color: bool = typer.Option(False, "--no-color", help="Disable colored output"),
-        **kwargs,
-    ) -> T:
-        # Configure logging for this command
-        log_dir = ensure_dom_directory()
-        log_file = log_dir / "domjudge-cli.log"
-        log_level = "DEBUG" if verbose else "INFO"
-        setup_logging(
-            level=log_level, log_file=log_file, enable_rich=not no_color, console_output=verbose
-        )
-
-        return func(*args, verbose=verbose, no_color=no_color, **kwargs)
-
-    return wrapper
-
-
-def cli_command(func: Callable[..., T]) -> Callable[..., T]:
-    """
-    Decorator for CLI commands with consistent error handling and logging.
-
-    This decorator:
-    - Catches DomJudgeCliError and exits with code 1
-    - Catches unexpected exceptions, logs them, and exits with code 1
-    - Provides consistent error messaging across all commands
-
-    Usage:
-        @app.command()
-        @cli_command
-        def my_command(arg: str):
-            # Command logic here
-            pass
-
-    Args:
-        func: The CLI command function to wrap
-
-    Returns:
-        Wrapped function with error handling
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs) -> T:
-        try:
-            return func(*args, **kwargs)
-        except DomJudgeCliError as e:
-            # Expected application errors
-            logger.error(f"Command failed: {e}")
-            raise typer.Exit(code=1) from e
-        except KeyboardInterrupt:
-            # User interrupted
-            logger.info("Command interrupted by user")
-            ui.blank()
-            ui.warn("** Operation cancelled by user")
-            raise typer.Exit(code=130) from None
-        except Exception as e:
-            # Unexpected errors - log with full traceback
-            logger.error(f"Unexpected error: {e}", exc_info=True)
-            ui.error(f"x Unexpected error: {e}")
-            ui.hint("Check logs at .dom/domjudge-cli.log for details")
-            raise typer.Exit(code=1) from e
-
-    return wrapper
 
 
 def find_file_with_extensions(
@@ -157,38 +44,19 @@ def find_file_with_extensions(
     extensions: tuple[str, str] = (".yaml", ".yml"),
     error_context: str | None = None,
 ) -> Path:
-    """
-    Find a file with .yaml or .yml extension, with fallback support.
+    """Find ``base_name.yaml`` or ``base_name.yml``.
 
-    This function abstracts the common pattern of looking for configuration files
-    that can have either .yaml or .yml extensions. It handles:
-    - Explicit file paths (returned as-is if they exist)
-    - Directory paths (searches for base_name.yaml or base_name.yml within)
-    - Base name only (searches in current directory)
-
-    Args:
-        base_path: Base path (file, directory, or relative name)
-        base_name: Base name of the file (e.g., "dom-judge", "problems")
-        extensions: Tuple of extensions to try (default: .yaml, .yml)
-        error_context: Optional context for error messages
-
-    Returns:
-        Path to the found file
-
-    Raises:
-        FileNotFoundError: If no file found with any extension
-        FileExistsError: If both .yaml and .yml exist
+    Accepts an explicit file path (returned as-is if it exists), a
+    directory (searched within), or a base name (searched in CWD).
+    Raises if both extensions resolve to existing files.
     """
     base_path = Path(base_path)
 
-    # If base_path is an explicit file that exists, return it
     if base_path.is_file():
         return base_path
 
-    # If base_path is a directory, search within it; otherwise use current directory
     search_dir = base_path if base_path.is_dir() else Path.cwd()
 
-    # Try both extensions
     ext1, ext2 = extensions
     path1 = search_dir / f"{base_name}{ext1}"
     path2 = search_dir / f"{base_name}{ext2}"
@@ -204,7 +72,6 @@ def find_file_with_extensions(
     if path2.is_file():
         return path2
 
-    # Nothing found
     raise FileNotFoundError(
         f"No '{base_name}{ext1}' or '{base_name}{ext2}' found in '{search_dir}'. "
         f"{error_context or ''}"
@@ -212,19 +79,7 @@ def find_file_with_extensions(
 
 
 def find_config_or_default(file: Path | None) -> Path:
-    """
-    Find configuration file or use default.
-
-    Args:
-        file: Optional explicit config file path
-
-    Returns:
-        Path to configuration file
-
-    Raises:
-        FileNotFoundError: If config file not found
-        FileExistsError: If both .yaml and .yml exist
-    """
+    """Return ``file`` if given, else search CWD for ``dom-judge.{yaml,yml}``."""
     if file:
         if not file.is_file():
             raise FileNotFoundError(f"Specified config file '{file}' not found.")
@@ -238,42 +93,10 @@ def find_config_or_default(file: Path | None) -> Path:
 
 
 def check_file_exists(file: Path) -> bool:
-    """
-    Check if file exists and raise error if it does.
-
-    Args:
-        file: File path to check
-
-    Returns:
-        False (file doesn't exist)
-
-    Raises:
-        FileExistsError: If file exists
-    """
+    """Raise ``FileExistsError`` if ``file`` exists; otherwise return ``False``."""
     if file.is_file():
         raise FileExistsError(
             f"File '{file}' already exists. "
             "Rename or remove the existing file, or use --overwrite to replace it."
         )
     return False
-
-
-def ask_override_if_exists(output_file: Path) -> bool:
-    """
-    Ask user whether to override if the output file exists.
-
-    Args:
-        output_file: Path to check
-
-    Returns:
-        True if should proceed, False if should skip
-    """
-    if output_file.exists():
-        override = ui.ask_bool(
-            f"File '{output_file}' exists. Do you want to override it?",
-            default=False,
-        )
-        if not override:
-            ui.warn("Skipping problem initialization.")
-            return False
-    return True

--- a/tests/unit/cli/test_render.py
+++ b/tests/unit/cli/test_render.py
@@ -1,0 +1,131 @@
+"""Tests for CLI-side change-set renderers (Rich-markup formatting)."""
+
+from pydantic import SecretStr
+
+from dom.cli.contest.render import format_contest_change_summary
+from dom.cli.infrastructure.render import format_change_summary
+from dom.core.services.contest.changes import (
+    ChangeType,
+    ContestChangeSet,
+    FieldChange,
+    ResourceChange,
+)
+from dom.core.services.infra.state import InfraChangeSet, InfraChangeType
+from dom.types.infra import InfraConfig
+
+
+def _config(**kwargs) -> InfraConfig:
+    base = {"port": 8080, "judges": 4, "password": SecretStr("test")}
+    base.update(kwargs)
+    return InfraConfig(**base)
+
+
+# ---------------------------------------------------------------- infra renderer
+
+
+def test_infra_summary_create():
+    cs = InfraChangeSet(change_type=InfraChangeType.CREATE, old_config=None, new_config=_config())
+    summary = format_change_summary(cs)
+    assert "CREATE" in summary
+    assert "new infrastructure" in summary
+
+
+def test_infra_summary_no_change():
+    cs = InfraChangeSet(
+        change_type=InfraChangeType.NO_CHANGE,
+        old_config=_config(),
+        new_config=_config(),
+    )
+    assert "NO CHANGES" in format_change_summary(cs)
+
+
+def test_infra_summary_scale_up():
+    cs = InfraChangeSet(
+        change_type=InfraChangeType.SCALE_JUDGES,
+        old_config=_config(judges=4),
+        new_config=_config(judges=8),
+        judge_diff=4,
+    )
+    summary = format_change_summary(cs)
+    assert "SCALE UP" in summary
+    assert "4" in summary and "8" in summary
+    assert "safe live change" in summary
+
+
+def test_infra_summary_scale_down():
+    cs = InfraChangeSet(
+        change_type=InfraChangeType.SCALE_JUDGES,
+        old_config=_config(judges=8),
+        new_config=_config(judges=4),
+        judge_diff=-4,
+    )
+    assert "SCALE DOWN" in format_change_summary(cs)
+
+
+def test_infra_summary_port_change():
+    cs = InfraChangeSet(
+        change_type=InfraChangeType.PORT_CHANGE,
+        old_config=_config(port=8080),
+        new_config=_config(port=9090),
+    )
+    summary = format_change_summary(cs)
+    assert "PORT CHANGE" in summary
+    assert "8080" in summary and "9090" in summary
+    assert "requires restart" in summary
+
+
+def test_infra_summary_password_change():
+    cs = InfraChangeSet(
+        change_type=InfraChangeType.PASSWORD_CHANGE,
+        old_config=_config(),
+        new_config=_config(),
+    )
+    assert "PASSWORD CHANGE" in format_change_summary(cs)
+
+
+def test_infra_summary_full_restart():
+    cs = InfraChangeSet(
+        change_type=InfraChangeType.FULL_RESTART,
+        old_config=_config(),
+        new_config=_config(),
+    )
+    assert "MULTIPLE CHANGES" in format_change_summary(cs)
+
+
+# ---------------------------------------------------------------- contest renderer
+
+
+def test_contest_summary_create():
+    cs = ContestChangeSet(
+        contest_shortname="test2025",
+        change_type=ChangeType.CREATE,
+        field_changes=[],
+        resource_changes=[],
+    )
+    summary = format_contest_change_summary(cs)
+    assert "CREATE" in summary
+    assert "test2025" in summary
+
+
+def test_contest_summary_update():
+    cs = ContestChangeSet(
+        contest_shortname="test2025",
+        change_type=ChangeType.UPDATE,
+        field_changes=[FieldChange("duration", "5:00:00", "6:00:00")],
+        resource_changes=[ResourceChange("problems", ["problem-a"], [], [])],
+    )
+    summary = format_contest_change_summary(cs)
+    assert "UPDATE" in summary
+    assert "test2025" in summary
+
+
+def test_contest_summary_no_change():
+    cs = ContestChangeSet(
+        contest_shortname="test2025",
+        change_type=ChangeType.NO_CHANGE,
+        field_changes=[],
+        resource_changes=[],
+    )
+    summary = format_contest_change_summary(cs)
+    assert "NO CHANGES" in summary
+    assert "test2025" in summary

--- a/tests/unit/operations/test_contest_operations.py
+++ b/tests/unit/operations/test_contest_operations.py
@@ -149,7 +149,7 @@ def test_render_planned_changes_renders_creates(capsys):
         field_changes=[],
         resource_changes=[],
     )
-    change_set.summary.return_value = "[CREATE] Contest C0"
+    change_set.summary_parts.return_value = (ChangeType.CREATE, "C0", [])
 
     render_planned_changes([{"shortname": "C0", "change_set": change_set}])
     output = capsys.readouterr().out

--- a/tests/unit/services/test_contest_state.py
+++ b/tests/unit/services/test_contest_state.py
@@ -197,48 +197,6 @@ class TestResourceChange:
 class TestContestChangeSet:
     """Tests for ContestChangeSet dataclass."""
 
-    def test_change_set_summary_for_create(self):
-        """Test summary message for CREATE."""
-        change_set = ContestChangeSet(
-            contest_shortname="test2025",
-            change_type=ChangeType.CREATE,
-            field_changes=[],
-            resource_changes=[],
-        )
-
-        summary = change_set.summary()
-        assert "CREATE" in summary
-        assert "test2025" in summary
-
-    def test_change_set_summary_for_update(self):
-        """Test summary message for UPDATE."""
-        field_changes = [FieldChange("duration", "5:00:00", "6:00:00")]
-        resource_changes = [ResourceChange("problems", ["problem-a"], [], [])]
-
-        change_set = ContestChangeSet(
-            contest_shortname="test2025",
-            change_type=ChangeType.UPDATE,
-            field_changes=field_changes,
-            resource_changes=resource_changes,
-        )
-
-        summary = change_set.summary()
-        assert "UPDATE" in summary
-        assert "test2025" in summary
-
-    def test_change_set_summary_for_no_change(self):
-        """Test summary message for NO_CHANGE."""
-        change_set = ContestChangeSet(
-            contest_shortname="test2025",
-            change_type=ChangeType.NO_CHANGE,
-            field_changes=[],
-            resource_changes=[],
-        )
-
-        summary = change_set.summary()
-        assert "NO CHANGES" in summary
-        assert "test2025" in summary
-
     def test_change_set_with_multiple_field_changes(self):
         """Test that multiple field changes are tracked."""
         field_changes = [

--- a/tests/unit/services/test_infra_state.py
+++ b/tests/unit/services/test_infra_state.py
@@ -6,7 +6,6 @@ from unittest.mock import MagicMock, patch
 from pydantic import SecretStr
 
 from dom.core.services.infra.state import (
-    InfraChangeSet,
     InfraChangeType,
     InfraStateComparator,
 )
@@ -164,32 +163,3 @@ class TestInfraStateComparator:
             state = comparator._load_current_state()
 
             assert state is None
-
-    def test_change_set_summary_for_create(self):
-        """Test summary message for CREATE change."""
-        change_set = InfraChangeSet(
-            change_type=InfraChangeType.CREATE,
-            old_config=None,
-            new_config=InfraConfig(port=8080, judges=4, password=SecretStr("test")),
-        )
-
-        summary = change_set.summary()
-
-        assert "CREATE" in summary
-        assert "new infrastructure" in summary
-
-    def test_change_set_summary_for_scale_up(self):
-        """Test summary message for scaling up judges."""
-        old = InfraConfig(port=8080, judges=4, password=SecretStr("test"))
-        new = InfraConfig(port=8080, judges=8, password=SecretStr("test"))
-
-        change_set = InfraChangeSet(
-            change_type=InfraChangeType.SCALE_JUDGES, old_config=old, new_config=new, judge_diff=4
-        )
-
-        summary = change_set.summary()
-
-        assert "SCALE UP" in summary
-        assert "4" in summary
-        assert "8" in summary
-        assert "safe live change" in summary

--- a/tests/unit/utils/test_cli_utils.py
+++ b/tests/unit/utils/test_cli_utils.py
@@ -6,10 +6,10 @@ from unittest.mock import patch
 import pytest
 import typer
 
+from dom.cli.decorators import cli_command
 from dom.exceptions import DomJudgeCliError
 from dom.utils.cli import (
     check_file_exists,
-    cli_command,
     ensure_dom_directory,
     find_config_or_default,
     get_secrets_manager,


### PR DESCRIPTION
## Summary

Tier 1 refactor from the recent code review. The operations framework, `utils/cli`, and infra state module each held presentation concerns that the import-linter had to whitelist. This removes those exceptions and tightens the layering.

- **Operations framework** is now presentation-agnostic: defines a `Renderer` protocol with a `_PlainRenderer` default. `dom/cli/runner.py` installs a `RichRenderer` that drives `rich.Progress` and `dom.ui`. Framework no longer imports `dom.ui` or `rich.progress`.
- **`dom/utils/cli.py`** is now pure filesystem/project utilities. CLI decorators (`add_global_options`, `cli_command`) moved to `dom/cli/decorators.py`; `ask_override_if_exists` moved to `dom/cli/helpers.py`.
- **`DockerClient`** split into `_DockerCli`, `DockerComposeManager`, `DockerHealthChecker`, `DockerCredentialManager` (SRP). `DockerClient` retained as a thin facade so existing callers and tests stay green; new code can depend on the focused subclients directly.
- **Rich markup removed** from `InfraChangeSet.summary` and `ContestChangeSet.summary`. CLI render modules own `format_change_summary` / `format_contest_change_summary` instead.
- **`.importlinter`** trimmed: dropped three `ignore_imports` entries (`dom.core.operations.framework -> dom.ui`, `dom.utils.cli -> dom.ui`) that no longer match. All 3 contracts pass clean.

Replaces #97 (rebased onto current main).

## Test plan

- [x] `pytest tests/unit tests/integration` — 317 passed
- [x] `lint-imports` — 3 contracts kept, 0 broken
- [x] `ruff check` — all clean
- [x] Pre-commit hooks (ruff, mypy, bandit) all pass