### PR TITLE
refactor: code-review follow-ups (DI, retry, UI boundary)

### DIFF
--- a/dom/cli/contest/inspect.py
+++ b/dom/cli/contest/inspect.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import jmespath
 import typer
 
+from dom import ui
 from dom.cli.contest.helpers import load_config_with_secrets
 from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.validators import validate_file_path
@@ -42,5 +43,9 @@ def inspect_command(
             return obj.isoformat()
         raise TypeError(f"Type {type(obj)} not serializable")
 
-    # pretty-print or just print the dict
-    typer.echo(json.dumps(data, ensure_ascii=False, indent=2, default=json_serializer))
+    # pretty-print or just print the dict; disable Rich markup so JSON brackets render verbatim
+    ui.console.print(
+        json.dumps(data, ensure_ascii=False, indent=2, default=json_serializer),
+        markup=False,
+        highlight=False,
+    )

--- a/dom/cli/infrastructure/destroy.py
+++ b/dom/cli/infrastructure/destroy.py
@@ -28,8 +28,8 @@ def destroy_command(
     Use ``--force-delete-volumes`` to permanently delete all data.
     """
     if not dry_run and not confirm:
-        typer.echo("! Use --confirm to actually destroy infrastructure.")
-        typer.echo("   Containers will be stopped. Use --force-delete-volumes to also delete data.")
+        ui.warn("Use --confirm to actually destroy infrastructure.")
+        ui.write("   Containers will be stopped. Use --force-delete-volumes to also delete data.")
         raise typer.Exit(code=1)
 
     if not dry_run:

--- a/dom/core/operations/contest/apply.py
+++ b/dom/core/operations/contest/apply.py
@@ -26,8 +26,8 @@ def _apply_all(config: DomConfig, ctx: Context) -> list[ContestApplyResult]:
         client,
         ctx.secrets,
         problem_service=ProblemService(client),
-        team_service=TeamService(client),
-        state_comparator=ContestStateComparator(client),
+        team_service=TeamService(client, ctx.secrets),
+        state_comparator=ContestStateComparator(client, ctx.secrets),
     )
     return [service.apply_contest(contest) for contest in config.contests]
 

--- a/dom/core/operations/contest/plan_changes.py
+++ b/dom/core/operations/contest/plan_changes.py
@@ -17,7 +17,7 @@ def _summary(changes: list[dict[str, Any]]) -> str:
 def plan_contest_changes_op(ctx: Context, config: DomConfig) -> list[dict[str, Any]]:
     """Compute per-contest change sets. Rendering is the CLI's job."""
     client = wire_admin_api(config.infra, ctx.secrets)
-    comparator = ContestStateComparator(client)
+    comparator = ContestStateComparator(client, ctx.secrets)
     return [
         {"shortname": contest.shortname, "change_set": comparator.compare_contest(contest)}
         for contest in config.contests

--- a/dom/core/services/contest/apply.py
+++ b/dom/core/services/contest/apply.py
@@ -61,8 +61,8 @@ class ContestApplicationService:
         self.client = client
         self.secrets = secrets
         self.problem_service = problem_service or ProblemService(client)
-        self.team_service = team_service or TeamService(client)
-        self.state_comparator = state_comparator or ContestStateComparator(client)
+        self.team_service = team_service or TeamService(client, secrets)
+        self.state_comparator = state_comparator or ContestStateComparator(client, secrets)
 
     # ------------------------------------------------------------------ public
 

--- a/dom/core/services/contest/state.py
+++ b/dom/core/services/contest/state.py
@@ -23,7 +23,7 @@ from dom.core.services.protocols import DomJudgeAPIProtocol
 from dom.exceptions import APIError, ContestError
 from dom.logging_config import get_logger
 from dom.types.config.processed import ContestConfig
-from dom.utils.cli import get_secrets_manager
+from dom.types.secrets import SecretsProvider
 from dom.utils.hashing import generate_team_username
 
 logger = get_logger(__name__)
@@ -122,8 +122,9 @@ class ContestStateComparator:
     create-vs-skip per contest).
     """
 
-    def __init__(self, client: DomJudgeAPIProtocol):
+    def __init__(self, client: DomJudgeAPIProtocol, secrets: SecretsProvider):
         self.client = client
+        self.secrets = secrets
 
     def compare_contest(
         self, desired: ContestConfig, current: dict[str, Any] | None = None
@@ -214,9 +215,8 @@ class ContestStateComparator:
         seed for stable hashing) so the comparison is an exact string match.
         Display names are projected back through the ``key → name`` map.
         """
-        secrets = get_secrets_manager()
         composite_to_display: dict[str, str] = {
-            f"{generate_team_username(secrets, t.composite_key)}|{t.composite_key}": t.name
+            f"{generate_team_username(self.secrets, t.composite_key)}|{t.composite_key}": t.name
             for t in desired.teams
         }
 

--- a/dom/core/services/contest/verification.py
+++ b/dom/core/services/contest/verification.py
@@ -51,7 +51,7 @@ def create_temp_contest(
     context = ServiceContext(client=client, contest_id=result.id, contest_shortname=temp_name)
 
     problem_service = ProblemService(client)
-    team_service = TeamService(client)
+    team_service = TeamService(client, secrets_mgr)
 
     problem_results = problem_service.create_many(contest.problems, context, stop_on_error=False)
     problem_summary = problem_service.get_summary(problem_results)

--- a/dom/core/services/team/apply.py
+++ b/dom/core/services/team/apply.py
@@ -12,7 +12,9 @@ from dom.core.services.base import BulkOperationMixin, Service, ServiceContext, 
 from dom.exceptions import APIError, TeamError
 from dom.logging_config import get_logger
 from dom.types.api.models import AddOrganization, AddTeam, AddUser
+from dom.types.secrets import SecretsProvider
 from dom.types.team import Team
+from dom.utils.hashing import deterministic_hash
 
 logger = get_logger(__name__)
 
@@ -27,6 +29,10 @@ class TeamService(Service[Team], BulkOperationMixin[Team]):
     This service is idempotent - running multiple times with the same teams
     will not create duplicates.
     """
+
+    def __init__(self, client, secrets: SecretsProvider):
+        super().__init__(client)
+        self.secrets = secrets
 
     def entity_name(self) -> str:
         """Return entity name."""
@@ -60,14 +66,11 @@ class TeamService(Service[Team], BulkOperationMixin[Team]):
             # so different organizations can have teams with the same display name.
             composite_key = entity.composite_key
 
-            # NOTE: Python's built-in hash() is salted per process (PYTHONHASHSEED),
-            # so this team_id is stable WITHIN one apply run but NOT across runs.
-            # DOMjudge's idempotency relies on the composite ``name`` below (which
-            # uses entity.username, generated via deterministic_hash) — the API
-            # treats name collisions as the same team, so a fresh team_id on a
-            # re-run is harmless. Don't replace with deterministic_hash without
-            # understanding the migration implications for existing deployments.
-            team_id = str(hash(composite_key) % HASH_MODULUS)
+            # Stable team_id across runs (uses the persisted hash seed). DOMjudge
+            # still dedupes by composite ``name`` below; making team_id stable
+            # makes log/debug correlation easier and the request payload
+            # reproducible.
+            team_id = str(deterministic_hash(self.secrets, composite_key, modulo=HASH_MODULUS))
 
             # The composite team name IS the join key. ``entity.username`` is
             # ``team{deterministic_hash}`` set by the config loader, so this
@@ -158,10 +161,10 @@ class TeamService(Service[Team], BulkOperationMixin[Team]):
         """
         org_country = country or DEFAULT_COUNTRY_CODE
         # ``MIT|USA`` and ``MIT|GBR`` are different organizations.
-        # Same caveat as team_id: hash() is per-process, so org_id is stable
-        # within a run but not across runs. DOMjudge dedupes by name + country.
+        # Stable across runs via the persisted hash seed; DOMjudge dedupes by
+        # name + country regardless.
         org_composite_key = f"{affiliation}|{org_country}"
-        org_id = str(hash(org_composite_key) % HASH_MODULUS)
+        org_id = str(deterministic_hash(self.secrets, org_composite_key, modulo=HASH_MODULUS))
 
         org_result = self.client.organizations.add_to_contest(
             contest_id=context.contest_id,  # type: ignore[arg-type]

--- a/dom/exceptions.py
+++ b/dom/exceptions.py
@@ -69,10 +69,19 @@ class PermanentAPIError(APIError):
 class APIRateLimitError(RetryableAPIError):
     """Raised when API rate limit is exceeded (HTTP 429).
 
-    This is retryable but should respect Retry-After header.
+    Retryable, with the wait derived from the server's ``Retry-After`` header
+    when present. Falls back to the configured exponential backoff otherwise.
     """
 
-    pass
+    def __init__(
+        self,
+        message: str,
+        status_code: int | None = None,
+        response_body: str | None = None,
+        retry_after: float | None = None,
+    ):
+        super().__init__(message, status_code=status_code, response_body=response_body)
+        self.retry_after = retry_after
 
 
 class APIAuthenticationError(PermanentAPIError):

--- a/dom/infrastructure/api/client.py
+++ b/dom/infrastructure/api/client.py
@@ -5,6 +5,8 @@ retry. Service classes build on top of this for specific resource types.
 """
 
 from collections.abc import Callable
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any, TypeVar
 
 import requests
@@ -16,6 +18,7 @@ from dom.exceptions import (
     APIError,
     APINetworkError,
     APINotFoundError,
+    APIRateLimitError,
     APIServerError,
 )
 from dom.infrastructure.api.cache import TTLCache
@@ -95,6 +98,7 @@ class DomJudgeClient:
         Raises:
             APIAuthenticationError: For 401/403 errors (permanent)
             APINotFoundError: For 404 errors (permanent)
+            APIRateLimitError: For 429 errors (retryable, honors Retry-After)
             APIServerError: For 5xx errors (retryable)
             APIError: For other HTTP errors
         """
@@ -114,6 +118,19 @@ class DomJudgeClient:
                 f"Resource not found: {response.text}",
                 status_code=status,
                 response_body=response.text,
+            )
+
+        elif status == 429:
+            retry_after = _parse_retry_after(response.headers.get("Retry-After"))
+            logger.warning(
+                f"Rate limited (429); Retry-After={retry_after}",
+                extra={"retry_after": retry_after},
+            )
+            raise APIRateLimitError(
+                f"Rate limited: {response.text}",
+                status_code=status,
+                response_body=response.text,
+                retry_after=retry_after,
             )
 
         elif 500 <= status < 600:
@@ -236,3 +253,19 @@ class DomJudgeClient:
     def delete(self, path: str, invalidate_cache: str | None = None, **kwargs) -> None:
         """Perform DELETE request with retry."""
         self._retry(lambda: self._delete_internal(path, invalidate_cache, **kwargs))
+
+
+def _parse_retry_after(value: str | None) -> float | None:
+    """Parse a ``Retry-After`` header into seconds. Accepts integer-seconds or HTTP-date."""
+    if not value:
+        return None
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+    try:
+        target = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        return None
+    now = datetime.now(timezone.utc) if target.tzinfo else datetime.now()
+    return max(0.0, (target - now).total_seconds())

--- a/dom/infrastructure/api/retry.py
+++ b/dom/infrastructure/api/retry.py
@@ -10,7 +10,7 @@ from collections.abc import Callable
 from functools import wraps
 from typing import Any, TypeVar
 
-from dom.exceptions import APIRateLimitError, PermanentAPIError, RetryableAPIError
+from dom.exceptions import PermanentAPIError, RetryableAPIError
 from dom.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -78,15 +78,13 @@ def is_retryable_error(error: Exception) -> bool:
         True if the error should be retried
 
     Examples:
-        - RetryableAPIError (5xx, network errors) → True
+        - RetryableAPIError (5xx, network errors, 429) → True
         - PermanentAPIError (4xx, auth failures) → False
-        - APIRateLimitError → False (HTTP 429; should respect Retry-After)
+        - APIRateLimitError → True (HTTP 429; sleep honors Retry-After)
     """
-    # Don't blindly retry HTTP 429 — Retry-After must be respected.
-    if isinstance(error, APIRateLimitError):
-        return False
-
-    # Retry errors explicitly marked as retryable
+    # Retry errors explicitly marked as retryable (includes APIRateLimitError).
+    # The actual sleep duration is computed in the wrapper so that 429s respect
+    # the server-supplied Retry-After value instead of pure exponential backoff.
     if isinstance(error, RetryableAPIError):
         return True
 
@@ -153,8 +151,13 @@ def with_retry(config: RetryConfig | None = None) -> Callable[[Callable[..., T]]
                         )
                         raise
 
-                    # Calculate delay and wait
-                    delay = calculate_delay(attempt, config)
+                    # Honor server-supplied Retry-After when present (HTTP 429),
+                    # otherwise fall back to exponential backoff.
+                    retry_after = getattr(e, "retry_after", None)
+                    if isinstance(retry_after, int | float) and retry_after >= 0:
+                        delay = min(float(retry_after), config.max_delay)
+                    else:
+                        delay = calculate_delay(attempt, config)
                     logger.warning(
                         f"Retrying {func.__name__} after error: {e}. "
                         f"Attempt {attempt + 1}/{config.max_retries}, "

--- a/tests/unit/services/test_contest_state.py
+++ b/tests/unit/services/test_contest_state.py
@@ -24,9 +24,16 @@ class TestContestStateComparator:
         return client
 
     @pytest.fixture
-    def comparator(self, mock_client):
-        """Create a ContestStateComparator with mocked client."""
-        return ContestStateComparator(mock_client)
+    def mock_secrets(self):
+        """Mocked SecretsProvider — only ``get_or_create_hash_seed`` is exercised."""
+        secrets = MagicMock()
+        secrets.get_or_create_hash_seed.return_value = "test-seed"
+        return secrets
+
+    @pytest.fixture
+    def comparator(self, mock_client, mock_secrets):
+        """Create a ContestStateComparator with mocked client and secrets."""
+        return ContestStateComparator(mock_client, mock_secrets)
 
     def test_compare_contest_detects_new_contest(self, comparator, mock_client):
         """Test that CREATE is detected for new contests."""


### PR DESCRIPTION
## Summary

Surgical follow-ups from a code-review pass. Five small, independently reviewable fixes; no behavior change for the happy path.

- **DI for `ContestStateComparator`** — replaces a global `get_secrets_manager()` call with constructor injection. Three call sites + the test fixture updated.
- **Stable team/org IDs** — `TeamService` now takes a `SecretsProvider` and uses `deterministic_hash(...)` instead of process-salted `hash()`, so IDs are reproducible across runs. DOMjudge still dedupes by composite name; this just makes the request payload deterministic.
- **HTTP 429 → `APIRateLimitError`** — `handle_response_error` had no 429 branch, so the dedicated rate-limit exception was never raised in practice. It is now, and it carries a parsed `retry_after` (integer-seconds or HTTP-date). The retry wrapper honors that value when present and falls back to exponential backoff otherwise.
- **UI boundary** — replace stray `typer.echo` calls in `contest/inspect.py` (uses `ui.console.print(..., markup=False)` so JSON brackets render verbatim) and `infrastructure/destroy.py`.

## Test plan
- [x] `pytest tests/unit` — 305 passed
- [x] `ruff check dom tests` — clean
- [x] `mypy dom` — clean
- [x] `lint-imports` — 3/3 contracts kept
- [x] Pre-commit hooks pass on commit