### PR TITLE
refactor: code-review priority fixes (logger, UI boundary, tests, docs)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -28,10 +28,6 @@ forbidden_modules =
 # Only dom.cli (the presentation layer) is allowed to talk to it. Business code
 # (services, infrastructure, types, validation, templates) must NOT import dom.ui;
 # instead, return structured data and let the CLI render it.
-#
-# A handful of legacy modules still import dom.ui — they're listed under
-# ignore_imports below with a note. Each one represents a future refactor; new
-# code must not extend the list.
 [importlinter:contract:ui-only-from-cli]
 name = Only dom.cli may import dom.ui
 type = forbidden
@@ -50,7 +46,3 @@ forbidden_modules =
 ignore_imports =
     # logging_config wires the shared Console into RichHandler — it needs the singleton.
     dom.logging_config -> dom.ui.console
-    # preview_csv renders a Rich table for the user during the init wizard.
-    dom.utils.csv_preview -> dom.ui
-    # warn_if_privileged_port surfaces a user-visible warning before infra apply.
-    dom.utils.prerequisites -> dom.ui

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,195 @@
+# Contributing to dom-cli
+
+Thanks for working on this project. This guide covers the architecture
+and the steps to add a new CLI command end-to-end. For coding style
+(ruff, mypy, bandit) and tests, see the `Makefile` — `make check` runs
+everything.
+
+## Setup
+
+```sh
+make setup       # install package + dev deps + pre-commit hooks
+make check       # format, lint, typecheck, test
+```
+
+## Architecture
+
+The codebase is split into four layers, with imports allowed only
+top-down. The contracts are enforced by `import-linter` (`.importlinter`):
+
+```
+dom.cli            ← presentation: Typer commands, ui, decorators
+   │
+   ▼
+dom.core.operations ← orchestration: declarative @operation steps
+   │
+   ▼
+dom.core.services   ← business logic: knows HOW; owns I/O
+   │
+   ▼
+dom.infrastructure  ← Docker, API client, secrets, templates
+```
+
+Two cross-cutting rules:
+
+- **No reverse imports.** Services and infrastructure cannot see
+  operations or CLI.
+- **UI is `dom.cli`-only.** Anything outside `dom.cli` that wants to
+  show something must return structured data; the CLI renders it.
+
+Supporting packages (`dom.types`, `dom.utils`, `dom.validation`,
+`dom.templates`, `dom.exceptions`) are leaf-style: they're consumed by
+all layers and import nothing layer-specific.
+
+### Roles
+
+| Layer | What it does | What it must NOT do |
+|---|---|---|
+| `dom.cli` | Parse args, load config, render output, handle errors | Business logic, I/O, Docker calls |
+| `dom.core.operations` | Sequence service calls into named `Step`s; build a `Plan`/`Steps` | Reach for `subprocess`, `DockerClient`, `requests`, files |
+| `dom.core.services` | Talk to API/Docker/secrets; expose intent-named verbs | Touch `dom.ui`, import operations or CLI |
+| `dom.infrastructure` | Concrete clients, retry, cache, templates | Know about contests/teams/problems as domain concepts |
+
+The reference implementation of the operation→service split is the
+infrastructure pipeline:
+`dom.core.operations.infrastructure.apply.apply_infrastructure_op`
+sequences `InfraService` verbs into named, progress-tracked steps.
+
+## Adding a new CLI command
+
+Suppose we want `dom contest freeze` — freeze the scoreboard of a
+running contest. Wire it in five files:
+
+### 1. Add a service method (`dom/core/services/contest/...`)
+
+Services own the actual work. Either extend an existing service or
+create a new one. The service receives the API client (or other deps)
+in `__init__`:
+
+```python
+# dom/core/services/contest/scoreboard.py
+from dom.core.services.protocols import DomJudgeAPIProtocol
+
+
+class ScoreboardService:
+    def __init__(self, client: DomJudgeAPIProtocol):
+        self.client = client
+
+    def freeze(self, contest_id: str) -> None:
+        self.client.contests.freeze(contest_id)
+```
+
+### 2. Wrap it in an operation (`dom/core/operations/contest/...`)
+
+Operations are decorated with `@operation` and return either a `Steps`
+list (multi-step, progress-tracked) or a single value:
+
+```python
+# dom/core/operations/contest/freeze.py
+from dom.core.operations.framework import Context, Step, Steps, operation
+from dom.core.operations.wiring import wire_admin_api
+from dom.core.services.contest.scoreboard import ScoreboardService
+from dom.types.config.processed import DomJudgeConfig
+
+
+@operation("Freeze contest scoreboard")
+def freeze_contest_op(ctx: Context, config: DomJudgeConfig) -> Steps:
+    api = wire_admin_api(config.infra, ctx.secrets)
+    svc = ScoreboardService(api)
+    return Steps(
+        steps=[
+            Step(f"Freeze contest {c.shortname}", lambda c=c: svc.freeze(c.shortname))
+            for c in config.contests
+        ],
+        summary=f"Froze {len(config.contests)} contest(s)",
+    )
+```
+
+### 3. Add the CLI command (`dom/cli/contest/...`)
+
+The CLI loads config + secrets, then runs the operation:
+
+```python
+# dom/cli/contest/freeze.py
+from pathlib import Path
+import typer
+
+from dom.cli.contest.helpers import load_dom_config_with_secrets
+from dom.cli.decorators import add_global_options, cli_command
+from dom.cli.validators import validate_file_path
+from dom.core.operations import Context, run
+from dom.core.operations.contest.freeze import freeze_contest_op
+
+
+@add_global_options
+@cli_command
+def freeze_command(
+    file: Path = typer.Option(
+        None, "-f", "--file", help="Path to configuration YAML file",
+        callback=validate_file_path,
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run"),
+    verbose: bool = False,
+    no_color: bool = False,  # noqa: ARG001
+) -> None:
+    """Freeze scoreboards for all configured contests."""
+    config, secrets = load_dom_config_with_secrets(file, verbose)
+    run(
+        freeze_contest_op(config),
+        Context(secrets=secrets, dry_run=dry_run, verbose=verbose),
+    )
+```
+
+### 4. Register it (`dom/cli/contest/__init__.py`)
+
+```python
+contest_command.command("freeze")(freeze_command)
+```
+
+The top-level `dom/cli/__init__.py` already wires `contest_command` to
+`app`, so nothing else is needed there.
+
+### 5. Test it
+
+Three test layers, in order of preference:
+
+- **Service unit tests** — mock the API client; test the verb's
+  contract. See `tests/unit/services/test_problem_service.py` for the
+  pattern.
+- **Operation tests** — patch the service class; assert the step labels
+  and order, plus that the right service methods get called. See
+  `tests/unit/operations/test_infrastructure_apply.py`.
+- **CLI integration tests** — use Typer's `CliRunner` to invoke the
+  command. See `tests/integration/test_cli.py`.
+
+Run `make test` (or `pytest`) before opening a PR. `make check` also
+runs lint and typecheck.
+
+## Common pitfalls
+
+- **Don't import `dom.ui` from outside `dom.cli`.** Return data; let
+  the CLI render. `import-linter` will fail the build if you do.
+- **Don't put logic in operations.** If a Step lambda does anything
+  beyond calling a service method, the logic belongs in the service.
+- **Don't reach into `requests` / `subprocess` / `DockerClient` from
+  operations.** That's the service layer's job. Operations get an
+  injected client via `wire_admin_api(config.infra, ctx.secrets)`.
+- **Avoid amending commits.** Pre-commit hooks will fail and roll back
+  cleanly; create a new commit instead.
+
+## Where things live
+
+| Concern | Location |
+|---|---|
+| Typer command definitions | `dom/cli/<group>/<verb>.py` |
+| Global CLI options + error handling | `dom/cli/decorators.py` |
+| Operations (orchestration) | `dom/core/operations/<group>/<verb>.py` |
+| Services (business logic) | `dom/core/services/<group>/...` |
+| API client + retry + cache | `dom/infrastructure/api/` |
+| Docker client | `dom/infrastructure/docker/` |
+| Secrets | `dom/infrastructure/secrets/` |
+| Domain types (Pydantic) | `dom/types/` |
+| Cross-cutting helpers | `dom/utils/` |
+| Validation rules | `dom/validation/` |
+| Jinja templates | `dom/templates/` |
+| Layering contracts | `.importlinter` |

--- a/dom/cli/__init__.py
+++ b/dom/cli/__init__.py
@@ -11,7 +11,7 @@ from dom.cli.contest import contest_command
 from dom.cli.infrastructure import infra_command
 from dom.cli.init import init_command
 from dom.logging_config import get_logger, setup_logging
-from dom.utils.cli import ensure_dom_directory
+from dom.utils.project import ensure_dom_directory
 
 logger = get_logger(__name__)
 

--- a/dom/cli/contest/verify_problemset.py
+++ b/dom/cli/contest/verify_problemset.py
@@ -8,7 +8,7 @@ from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.validators import validate_contest_name, validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.contest import verify_problemset_op
-from dom.utils.cli import get_secrets_manager
+from dom.utils.project import get_secrets_manager
 
 
 @add_global_options

--- a/dom/cli/decorators.py
+++ b/dom/cli/decorators.py
@@ -2,7 +2,7 @@
 
 These belong to the CLI layer (presentation): they configure logging,
 catch errors, and render user-visible messages via ``dom.ui``. They
-were previously in ``dom.utils.cli`` — moved here so utilities stay
+were previously in ``dom.utils.project`` — moved here so utilities stay
 free of UI concerns.
 """
 
@@ -17,7 +17,7 @@ import typer
 from dom import ui
 from dom.exceptions import DomJudgeCliError
 from dom.logging_config import get_logger, setup_logging
-from dom.utils.cli import ensure_dom_directory
+from dom.utils.project import ensure_dom_directory
 
 logger = get_logger(__name__)
 

--- a/dom/cli/helpers.py
+++ b/dom/cli/helpers.py
@@ -14,7 +14,7 @@ from dom import ui
 from dom.core.operations import Context, run
 from dom.core.operations.framework import Operation
 from dom.types.secrets import SecretsProvider
-from dom.utils.cli import get_secrets_manager
+from dom.utils.project import get_secrets_manager
 
 T = TypeVar("T")
 

--- a/dom/cli/infrastructure/apply.py
+++ b/dom/cli/infrastructure/apply.py
@@ -4,11 +4,13 @@ from pathlib import Path
 
 import typer
 
+from dom import ui
 from dom.cli.decorators import add_global_options, cli_command
 from dom.cli.infrastructure.helpers import load_infra_config_with_secrets
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.infrastructure import apply_infrastructure_op
+from dom.utils.prerequisites import is_privileged_port
 
 
 @add_global_options
@@ -26,6 +28,10 @@ def apply_command(
     Use ``--dry-run`` to preview the steps that would run.
     """
     config, secrets = load_infra_config_with_secrets(file, verbose)
+    if is_privileged_port(config.port):
+        ui.warn(f"** Warning: Port {config.port} is privileged (< 1024)")
+        ui.warn("   You may need to run with sudo or use a port >= 1024")
+        ui.blank()
     run(
         apply_infrastructure_op(config),
         Context(secrets=secrets, dry_run=dry_run, verbose=verbose),

--- a/dom/cli/infrastructure/destroy.py
+++ b/dom/cli/infrastructure/destroy.py
@@ -6,7 +6,7 @@ from dom import ui
 from dom.cli.decorators import add_global_options, cli_command
 from dom.core.operations import Context, run
 from dom.core.operations.infrastructure import destroy_infrastructure_op
-from dom.utils.cli import get_secrets_manager
+from dom.utils.project import get_secrets_manager
 
 
 @add_global_options

--- a/dom/cli/infrastructure/status.py
+++ b/dom/cli/infrastructure/status.py
@@ -9,7 +9,7 @@ from dom.cli.infrastructure.render import render_status
 from dom.cli.validators import validate_file_path
 from dom.core.operations import Context, run
 from dom.core.operations.infrastructure import check_infra_status_op
-from dom.utils.cli import get_secrets_manager
+from dom.utils.project import get_secrets_manager
 
 
 @add_global_options

--- a/dom/cli/init/wizard/callback.py
+++ b/dom/cli/init/wizard/callback.py
@@ -6,7 +6,7 @@ from dom import ui
 from dom.cli.init.wizard.contest import initialize_contest
 from dom.cli.init.wizard.infra import initialize_infrastructure
 from dom.cli.init.wizard.problems import initialize_problems
-from dom.utils.cli import check_file_exists
+from dom.utils.project import check_file_exists
 
 
 def run_wizard(overwrite: bool) -> None:

--- a/dom/cli/init/wizard/contest.py
+++ b/dom/cli/init/wizard/contest.py
@@ -6,10 +6,10 @@ from rich.table import Table
 from dom import ui
 from dom.templates.init import contest_template
 from dom.utils.csv_preview import (
+    build_csv_preview,
     column_index_parser,
     count_csv_rows,
     get_column_count,
-    preview_csv,
 )
 from dom.utils.time import format_datetime, format_duration
 from dom.utils.validators import ValidatorBuilder
@@ -82,20 +82,28 @@ def initialize_contest():
     ui.header("CSV Preview")
     teams_file_path = Path(teams_path)
 
-    has_header = preview_csv(teams_file_path, delimiter, max_rows=10, show_column_numbers=True)
+    table, has_header = build_csv_preview(
+        teams_file_path, delimiter, max_rows=10, show_column_numbers=True
+    )
+    if table is None:
+        ui.warn("Warning: CSV file is empty")
+    else:
+        ui.render(table)
 
     confirmed = ui.ask_bool("Does the first row contain headers?", default=has_header)
     if confirmed != has_header:
         has_header = confirmed
         label = "with header" if has_header else "no header"
         ui.header(f"Updated CSV Preview ({label})")
-        preview_csv(
+        table, _ = build_csv_preview(
             teams_file_path,
             delimiter,
             max_rows=10,
             show_column_numbers=True,
             has_header=has_header,
         )
+        if table is not None:
+            ui.render(table)
 
     num_columns = get_column_count(teams_file_path, delimiter)
 

--- a/dom/core/config/loaders/__init__.py
+++ b/dom/core/config/loaders/__init__.py
@@ -5,7 +5,7 @@ import yaml
 from dom.types.config.processed import ContestConfig, DomConfig, InfraConfig
 from dom.types.config.raw import RawDomConfig
 from dom.types.secrets import SecretsProvider
-from dom.utils.cli import find_config_or_default
+from dom.utils.project import find_config_or_default
 
 from .contest import load_contest_from_config, load_contests_from_config
 from .infra import load_infra_from_config

--- a/dom/core/config/loaders/problem.py
+++ b/dom/core/config/loaders/problem.py
@@ -18,8 +18,8 @@ from dom.types.problem import (
     ProblemYAML,
     Submissions,
 )
-from dom.utils.cli import find_file_with_extensions
 from dom.utils.color import get_hex_color
+from dom.utils.project import find_file_with_extensions
 from dom.utils.sys import load_folder_as_dict
 
 logger = get_logger(__name__)

--- a/dom/core/operations/infrastructure/apply.py
+++ b/dom/core/operations/infrastructure/apply.py
@@ -10,7 +10,7 @@ def apply_infrastructure_op(ctx: Context, config: InfraConfig) -> Steps:
     svc = InfraService(ctx.secrets)
     return Steps(
         steps=[
-            Step("Validate prerequisites", lambda: _validate(svc, config.port)),
+            Step("Validate prerequisites", lambda: svc.validate_prerequisites(config.port)),
             Step("Generate compose file", lambda: svc.generate_compose_bootstrap(config)),
             Step("Start MariaDB", lambda: svc.start_service("mariadb")),
             Step("Start MySQL client", lambda: svc.start_service("mysql-client")),
@@ -28,8 +28,3 @@ def apply_infrastructure_op(ctx: Context, config: InfraConfig) -> Steps:
             f" • {config.judges} judgehost(s) running"
         ),
     )
-
-
-def _validate(svc: InfraService, port: int) -> None:
-    svc.validate_prerequisites(port)
-    svc.warn_privileged_port(port)

--- a/dom/core/services/base.py
+++ b/dom/core/services/base.py
@@ -4,7 +4,6 @@ This module provides declarative base classes for building services
 that follow clean architecture principles.
 """
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Generic, TypeVar
 
@@ -77,7 +76,7 @@ class ServiceResult(Generic[TOutput]):
         return self.data
 
 
-class Service(ABC, Generic[TEntity]):
+class Service(Generic[TEntity]):
     """
     Base class for declarative services.
 
@@ -99,10 +98,6 @@ class Service(ABC, Generic[TEntity]):
             client: DOMjudge API client
         """
         self.client = client
-
-    @abstractmethod
-    def entity_name(self) -> str:
-        """Return the name of the entity this service manages."""
 
 
 class BulkOperationMixin(Generic[TEntity]):

--- a/dom/core/services/infra/service.py
+++ b/dom/core/services/infra/service.py
@@ -17,11 +17,8 @@ from dom.infrastructure.docker.template import generate_docker_compose
 from dom.logging_config import get_logger
 from dom.types.infra import InfraConfig, InfrastructureStatus, ServiceStatus
 from dom.types.secrets import SecretsProvider
-from dom.utils.cli import ensure_dom_directory, get_container_prefix
-from dom.utils.prerequisites import (
-    validate_infrastructure_prerequisites,
-    warn_if_privileged_port,
-)
+from dom.utils.prerequisites import validate_infrastructure_prerequisites
+from dom.utils.project import ensure_dom_directory, get_container_prefix
 
 logger = get_logger(__name__)
 
@@ -40,9 +37,6 @@ class InfraService:
 
     def validate_prerequisites(self, port: int) -> None:
         validate_infrastructure_prerequisites(port)
-
-    def warn_privileged_port(self, port: int) -> None:
-        warn_if_privileged_port(port)
 
     # ------------------------------------------------------------------ Compose
 

--- a/dom/core/services/infra/state.py
+++ b/dom/core/services/infra/state.py
@@ -17,7 +17,7 @@ from pydantic import SecretStr
 from dom.constants import ContainerNames
 from dom.logging_config import get_logger
 from dom.types.infra import InfraConfig
-from dom.utils.cli import get_container_prefix, get_secrets_manager
+from dom.utils.project import get_container_prefix, get_secrets_manager
 
 logger = get_logger(__name__)
 

--- a/dom/core/services/problem/apply.py
+++ b/dom/core/services/problem/apply.py
@@ -19,10 +19,6 @@ class ProblemService(Service[ProblemPackage], BulkOperationMixin[ProblemPackage]
     proper error handling and concurrency control.
     """
 
-    def entity_name(self) -> str:
-        """Return entity name."""
-        return "Problem"
-
     def create(
         self, entity: ProblemPackage, context: ServiceContext
     ) -> ServiceResult[ProblemPackage]:

--- a/dom/core/services/team/apply.py
+++ b/dom/core/services/team/apply.py
@@ -34,10 +34,6 @@ class TeamService(Service[Team], BulkOperationMixin[Team]):
         super().__init__(client)
         self.secrets = secrets
 
-    def entity_name(self) -> str:
-        """Return entity name."""
-        return "Team"
-
     def create(self, entity: Team, context: ServiceContext) -> ServiceResult[Team]:
         """
         Add a single team to a contest.

--- a/dom/infrastructure/docker/containers.py
+++ b/dom/infrastructure/docker/containers.py
@@ -25,7 +25,7 @@ from dom.constants import HEALTH_CHECK_INTERVAL, HEALTH_CHECK_TIMEOUT, Container
 from dom.exceptions import DockerError
 from dom.logging_config import get_logger
 from dom.utils.bcrypt import generate_bcrypt_password
-from dom.utils.cli import get_container_prefix
+from dom.utils.project import get_container_prefix
 
 logger = get_logger(__name__)
 

--- a/dom/infrastructure/docker/template.py
+++ b/dom/infrastructure/docker/template.py
@@ -2,7 +2,7 @@ from dom.logging_config import get_logger
 from dom.templates.infra import docker_compose_template
 from dom.types.infra import InfraConfig
 from dom.types.secrets import SecretsProvider
-from dom.utils.cli import ensure_dom_directory, get_container_prefix
+from dom.utils.project import ensure_dom_directory, get_container_prefix
 
 logger = get_logger(__name__)
 

--- a/dom/logging_config.py
+++ b/dom/logging_config.py
@@ -80,9 +80,9 @@ def get_logger(name: str) -> logging.Logger:
     Get a logger instance for a specific module.
 
     Args:
-        name: Name of the logger (typically __name__)
+        name: Name of the logger (typically __name__, which already starts with "dom.")
 
     Returns:
         Logger instance
     """
-    return logging.getLogger(f"dom.{name}")
+    return logging.getLogger(name)

--- a/dom/utils/csv_preview.py
+++ b/dom/utils/csv_preview.py
@@ -6,7 +6,6 @@ from pathlib import Path
 
 from rich.table import Table
 
-from dom import ui
 from dom.logging_config import get_logger
 from dom.utils.validators import Invalid
 
@@ -115,25 +114,25 @@ def auto_detect_data_range(file_path: Path, delimiter: str) -> tuple[int, int]:
     return start_row, end_row
 
 
-def preview_csv(
+def build_csv_preview(
     file_path: Path,
     delimiter: str,
     max_rows: int = 10,
     show_column_numbers: bool = True,
     has_header: bool | None = None,
-) -> bool:
+) -> tuple[Table | None, bool]:
     """
-    Display a preview of the CSV file with Rich formatting.
+    Build a Rich table previewing a CSV file. Pure data — caller renders.
 
     Args:
         file_path: Path to CSV file
         delimiter: Field delimiter
-        max_rows: Maximum number of rows to display
-        show_column_numbers: Whether to show column numbers
+        max_rows: Maximum number of rows to include
+        show_column_numbers: Whether to label columns with their index
         has_header: Override header detection (None for auto-detect)
 
     Returns:
-        Whether the file has a header row
+        ``(table, has_header)`` — ``table`` is ``None`` if the file is empty.
     """
     rows = read_csv_rows(file_path, delimiter, max_rows=max_rows)
     total_rows = count_csv_rows(file_path, delimiter)
@@ -141,8 +140,7 @@ def preview_csv(
         has_header = detect_header_row(file_path, delimiter)
 
     if not rows:
-        ui.warn("Warning: CSV file is empty")
-        return False
+        return None, False
 
     num_columns = max(len(row) for row in rows)
 
@@ -170,8 +168,7 @@ def preview_csv(
         padded = row + [""] * (num_columns - len(row))
         table.add_row(str(start_index + offset), *padded)
 
-    ui.render(table)
-    return has_header
+    return table, has_header
 
 
 def get_column_count(file_path: Path, delimiter: str) -> int:

--- a/dom/utils/prerequisites.py
+++ b/dom/utils/prerequisites.py
@@ -8,10 +8,9 @@ import socket
 import subprocess  # nosec B404
 from pathlib import Path
 
-from dom import ui
 from dom.exceptions import ConfigError, DockerError, InfrastructureError
 from dom.logging_config import get_logger
-from dom.utils.cli import get_container_prefix
+from dom.utils.project import get_container_prefix
 
 logger = get_logger(__name__)
 
@@ -246,15 +245,6 @@ def validate_infrastructure_prerequisites(port: int | None = None) -> None:
     logger.info("Prerequisites validated successfully")
 
 
-def warn_if_privileged_port(port: int) -> None:
-    """
-    Warn user if using a privileged port (< 1024).
-
-    Args:
-        port: Port number to check
-    """
-    if port < 1024:
-        ui.warn(f"** Warning: Port {port} is privileged (< 1024)")
-        ui.warn("   You may need to run with sudo or use a port >= 1024")
-        ui.blank()
-        logger.warning(f"Using privileged port: {port}")
+def is_privileged_port(port: int) -> bool:
+    """Return True if ``port`` is privileged (requires elevated permissions on Unix)."""
+    return port < 1024

--- a/dom/utils/project.py
+++ b/dom/utils/project.py
@@ -1,9 +1,8 @@
 """Cross-layer filesystem / project utilities.
 
-These helpers are *not* CLI-specific even though the module name says
-"cli". They're consumed by services and infrastructure (e.g.
-``get_container_prefix``) as well as the CLI. UI-bearing decorators and
-prompts live in :mod:`dom.cli.decorators` and :mod:`dom.cli.helpers`.
+Consumed by CLI, services, and infrastructure (e.g. ``get_container_prefix``,
+``ensure_dom_directory``). UI-bearing decorators and prompts live in
+:mod:`dom.cli.decorators` and :mod:`dom.cli.helpers`.
 """
 
 from hashlib import sha256

--- a/tests/unit/operations/test_infrastructure_apply.py
+++ b/tests/unit/operations/test_infrastructure_apply.py
@@ -60,7 +60,6 @@ def test_run_executes_full_pipeline_in_order(context, config, mock_service):
     run(apply_infrastructure_op(config), context)
 
     mock_service.validate_prerequisites.assert_called_once_with(8080)
-    mock_service.warn_privileged_port.assert_called_once_with(8080)
     mock_service.generate_compose_bootstrap.assert_called_once_with(config)
     assert mock_service.start_service.call_count == 3  # mariadb, mysql-client, domserver
     mock_service.wait_domserver_healthy.assert_called_once()

--- a/tests/unit/services/test_infra_service.py
+++ b/tests/unit/services/test_infra_service.py
@@ -45,12 +45,6 @@ def test_validate_prerequisites_delegates_to_util(service):
         v.assert_called_once_with(8080)
 
 
-def test_warn_privileged_port_delegates_to_util(service):
-    with patch("dom.core.services.infra.service.warn_if_privileged_port") as w:
-        service.warn_privileged_port(80)
-        w.assert_called_once_with(80)
-
-
 # ---------------------------------------------------------------- Compose
 
 

--- a/tests/unit/services/test_problem_service.py
+++ b/tests/unit/services/test_problem_service.py
@@ -1,0 +1,121 @@
+"""Tests for ProblemService."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from dom.core.services.base import ServiceContext
+from dom.core.services.problem.apply import ProblemService
+from dom.exceptions import APIError, ProblemError
+
+
+def _problem(name: str = "p1") -> MagicMock:
+    """Build a stand-in for a ``ProblemPackage`` with the attrs the service reads."""
+    pkg = MagicMock()
+    pkg.yaml.name = name
+    pkg.id = None
+    return pkg
+
+
+@pytest.fixture
+def client():
+    """Mock matching the DomJudgeAPIProtocol surface used by ProblemService."""
+    return MagicMock()
+
+
+@pytest.fixture
+def service(client):
+    return ProblemService(client)
+
+
+@pytest.fixture
+def context(client):
+    return ServiceContext(client=client, contest_id="c1")
+
+
+# ---------------------------------------------------------------- create
+
+
+def test_create_returns_failure_when_contest_id_missing(service, client):
+    ctx = ServiceContext(client=client)  # no contest_id
+    result = service.create(_problem(), ctx)
+
+    assert result.success is False
+    assert isinstance(result.error, ValueError)
+    client.problems.add_to_contest.assert_not_called()
+
+
+def test_create_succeeds_and_assigns_returned_id(service, client, context):
+    client.problems.add_to_contest.return_value = "remote-42"
+    pkg = _problem("watermelon")
+
+    result = service.create(pkg, context)
+
+    assert result.success is True
+    assert result.created is True
+    assert result.data is pkg
+    assert pkg.id == "remote-42"
+    client.problems.add_to_contest.assert_called_once_with("c1", pkg)
+
+
+def test_create_wraps_api_error_as_problem_error(service, client, context):
+    client.problems.add_to_contest.side_effect = APIError("boom", status_code=500)
+
+    result = service.create(_problem("bitwalker"), context)
+
+    assert result.success is False
+    assert isinstance(result.error, ProblemError)
+    assert "bitwalker" in str(result.error)
+
+
+def test_create_does_not_swallow_unexpected_exceptions(service, client, context):
+    """Non-APIError surfaces — service only catches APIError on purpose."""
+    client.problems.add_to_contest.side_effect = RuntimeError("network died")
+
+    with pytest.raises(RuntimeError):
+        service.create(_problem(), context)
+
+
+# ---------------------------------------------------------------- create_many
+
+
+def test_create_many_returns_one_result_per_input(service, client, context):
+    client.problems.add_to_contest.side_effect = ["id-1", "id-2", "id-3"]
+
+    results = service.create_many([_problem("a"), _problem("b"), _problem("c")], context)
+
+    assert len(results) == 3
+    assert all(r.success for r in results)
+    assert client.problems.add_to_contest.call_count == 3
+
+
+def test_create_many_collects_partial_failures(service, client, context):
+    """A failing problem doesn't take down the others; it shows up as a failed result."""
+
+    def fake_add(contest_id, pkg):
+        if pkg.yaml.name == "broken":
+            raise APIError("nope", status_code=400)
+        return f"id-{pkg.yaml.name}"
+
+    client.problems.add_to_contest.side_effect = fake_add
+
+    results = service.create_many([_problem("a"), _problem("broken"), _problem("c")], context)
+
+    assert len(results) == 3
+    successes = [r for r in results if r.success]
+    failures = [r for r in results if not r.success]
+    assert len(successes) == 2
+    assert len(failures) == 1
+    assert isinstance(failures[0].error, ProblemError)
+
+
+def test_create_many_summary_counts_match(service, client, context):
+    client.problems.add_to_contest.side_effect = ["id-a", APIError("x", status_code=500), "id-c"]
+
+    results = service.create_many([_problem("a"), _problem("b"), _problem("c")], context)
+    summary = service.get_summary(results)
+
+    assert summary["total"] == 3
+    assert summary["successful"] == 2
+    assert summary["failed"] == 1
+    assert summary["created"] == 2

--- a/tests/unit/services/test_team_service.py
+++ b/tests/unit/services/test_team_service.py
@@ -1,0 +1,192 @@
+"""Tests for TeamService."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import SecretStr
+
+from dom.core.services.base import ServiceContext
+from dom.core.services.team.apply import TeamService
+from dom.exceptions import APIError, TeamError
+from dom.types.secrets import SecretsProvider
+from dom.types.team import Team
+
+
+def _team(
+    name: str = "Alpha",
+    affiliation: str | None = "MIT",
+    country: str | None = "USA",
+    username: str = "team1",
+) -> Team:
+    return Team(
+        name=name,
+        affiliation=affiliation,
+        country=country,
+        username=username,
+        password=SecretStr("hunter2"),
+    )
+
+
+@pytest.fixture
+def client():
+    """Mock matching the DomJudgeAPIProtocol surface used by TeamService."""
+    c = MagicMock()
+    c.organizations.add_to_contest.return_value = MagicMock(id="org-1")
+    c.teams.add_to_contest.return_value = MagicMock(id="team-1", created=True)
+    return c
+
+
+@pytest.fixture
+def secrets():
+    s = MagicMock(spec=SecretsProvider)
+    s.get_required.return_value = "deterministic-seed"
+    return s
+
+
+@pytest.fixture
+def service(client, secrets):
+    return TeamService(client, secrets)
+
+
+@pytest.fixture
+def context(client):
+    return ServiceContext(client=client, contest_id="c1", team_group_id="g1")
+
+
+# ---------------------------------------------------------------- create
+
+
+def test_create_returns_failure_when_contest_id_missing(service, client):
+    ctx = ServiceContext(client=client)
+    result = service.create(_team(), ctx)
+
+    assert result.success is False
+    assert isinstance(result.error, ValueError)
+    client.teams.add_to_contest.assert_not_called()
+
+
+def test_create_creates_organization_when_team_has_affiliation(service, client, context):
+    service.create(_team(affiliation="MIT", country="USA"), context)
+
+    client.organizations.add_to_contest.assert_called_once()
+    org_arg = client.organizations.add_to_contest.call_args.kwargs["organization"]
+    assert org_arg.name == "MIT"
+    assert org_arg.country == "USA"
+
+
+def test_create_skips_organization_when_team_has_no_affiliation(service, client, context):
+    service.create(_team(affiliation=None), context)
+
+    client.organizations.add_to_contest.assert_not_called()
+    client.teams.add_to_contest.assert_called_once()
+
+
+def test_create_uses_contest_team_group_when_provided(service, client, context):
+    service.create(_team(), context)
+
+    team_arg = client.teams.add_to_contest.call_args.kwargs["team_data"]
+    assert team_arg.group_ids == ["g1"]
+
+
+def test_create_falls_back_to_default_group_when_unset(service, client):
+    ctx = ServiceContext(client=client, contest_id="c1")  # no team_group_id
+    service.create(_team(), ctx)
+
+    team_arg = client.teams.add_to_contest.call_args.kwargs["team_data"]
+    assert team_arg.group_ids != ["g1"]
+    assert len(team_arg.group_ids) == 1  # default group set
+
+
+def test_create_marks_created_true_when_api_says_created(service, client, context):
+    client.teams.add_to_contest.return_value = MagicMock(id="team-7", created=True)
+    result = service.create(_team(name="Alpha"), context)
+
+    assert result.success is True
+    assert result.created is True
+    client.users.add.assert_called_once()  # user created on first creation
+
+
+def test_create_skips_user_creation_when_team_already_exists(service, client, context):
+    """Idempotency: pre-existing team → no user creation, but still success."""
+    client.teams.add_to_contest.return_value = MagicMock(id="team-7", created=False)
+
+    result = service.create(_team(), context)
+
+    assert result.success is True
+    assert result.created is False
+    client.users.add.assert_not_called()
+
+
+def test_create_wraps_api_error_as_team_error(service, client, context):
+    client.teams.add_to_contest.side_effect = APIError("boom", status_code=500)
+
+    result = service.create(_team(name="Beta"), context)
+
+    assert result.success is False
+    assert isinstance(result.error, TeamError)
+    assert "Beta" in str(result.error)
+
+
+def test_create_uses_display_name_distinct_from_join_name(service, client, context):
+    """``display_name`` is human-readable; ``name`` is the composite join key."""
+    service.create(_team(name="Alpha", username="team1"), context)
+
+    team_arg = client.teams.add_to_contest.call_args.kwargs["team_data"]
+    assert team_arg.display_name == "Alpha"
+    # composite name embeds the username and composite_key
+    assert team_arg.name.startswith("team1|Alpha|")
+
+
+# ---------------------------------------------------------------- create_many
+
+
+def test_create_many_returns_one_result_per_input(service, client, context):
+    client.teams.add_to_contest.return_value = MagicMock(id="t", created=True)
+
+    results = service.create_many(
+        [_team(name=n, username=f"u{i}") for i, n in enumerate(["A", "B", "C"])],
+        context,
+    )
+
+    assert len(results) == 3
+    assert all(r.success for r in results)
+
+
+def test_create_many_collects_partial_failures(service, client, context):
+    def fake_add(*, contest_id, team_data):
+        if "broken" in team_data.display_name:
+            raise APIError("nope", status_code=400)
+        return MagicMock(id="t", created=True)
+
+    client.teams.add_to_contest.side_effect = fake_add
+
+    results = service.create_many(
+        [
+            _team(name="ok1", username="u1"),
+            _team(name="broken", username="u2"),
+            _team(name="ok2", username="u3"),
+        ],
+        context,
+    )
+
+    assert len(results) == 3
+    assert sum(1 for r in results if r.success) == 2
+    assert sum(1 for r in results if not r.success) == 1
+
+
+def test_create_many_summary_counts_match(service, client, context):
+    client.teams.add_to_contest.side_effect = [
+        MagicMock(id="t1", created=True),
+        APIError("x", status_code=500),
+        MagicMock(id="t3", created=False),  # already exists
+    ]
+
+    results = service.create_many(
+        [_team(name=f"T{i}", username=f"u{i}") for i in range(3)], context
+    )
+    summary = service.get_summary(results)
+
+    assert summary["total"] == 3
+    assert summary["successful"] == 2
+    assert summary["failed"] == 1
+    assert summary["created"] == 1  # only one was newly created

--- a/tests/unit/utils/test_cli_utils.py
+++ b/tests/unit/utils/test_cli_utils.py
@@ -8,7 +8,7 @@ import typer
 
 from dom.cli.decorators import cli_command
 from dom.exceptions import DomJudgeCliError
-from dom.utils.cli import (
+from dom.utils.project import (
     check_file_exists,
     ensure_dom_directory,
     find_config_or_default,

--- a/tests/unit/utils/test_prerequisites.py
+++ b/tests/unit/utils/test_prerequisites.py
@@ -10,11 +10,11 @@ import pytest
 from dom.exceptions import ConfigError, DockerError, InfrastructureError
 from dom.utils.prerequisites import (
     is_port_used_by_domjudge,
+    is_privileged_port,
     validate_config_file,
     validate_docker_available,
     validate_infrastructure_prerequisites,
     validate_port_available,
-    warn_if_privileged_port,
 )
 
 
@@ -220,19 +220,13 @@ class TestValidateInfrastructurePrerequisites:
         mock_port.assert_not_called()
 
 
-class TestWarnIfPrivilegedPort:
-    """Tests for warn_if_privileged_port."""
+class TestIsPrivilegedPort:
+    """Tests for is_privileged_port."""
 
-    def test_warns_for_privileged_port(self):
-        from dom import ui
+    def test_returns_true_for_privileged_port(self):
+        assert is_privileged_port(80) is True
+        assert is_privileged_port(1023) is True
 
-        with patch.object(ui.console, "print") as mock_print:
-            warn_if_privileged_port(80)
-        assert mock_print.called
-
-    def test_silent_for_unprivileged_port(self):
-        from dom import ui
-
-        with patch.object(ui.console, "print") as mock_print:
-            warn_if_privileged_port(8080)
-        mock_print.assert_not_called()
+    def test_returns_false_for_unprivileged_port(self):
+        assert is_privileged_port(1024) is False
+        assert is_privileged_port(8080) is False

--- a/tests/unit/utils/test_project.py
+++ b/tests/unit/utils/test_project.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 
-from dom.utils.cli import find_file_with_extensions
+from dom.utils.project import find_file_with_extensions
 
 
 class TestFindFileWithExtensions:


### PR DESCRIPTION
## Summary

Follow-ups from a code review pass; six small, independent fixes bundled into one PR.

- **Logger prefix bug.** `get_logger(__name__)` was returning `dom.dom.<module>` because `get_logger` prepended `"dom."` to a name that already started with `dom.`. Fixed to use the name as-is. This restores hierarchical filtering (e.g. setting a level on `dom.cli` now actually affects descendants).
- **UI boundary cleanup.** Removed the two `dom.utils → dom.ui` import-linter exceptions:
  - `warn_if_privileged_port` (services-side, called UI directly) → `is_privileged_port` returning `bool`; the actual `ui.warn` now lives in `dom/cli/infrastructure/apply.py`.
  - `preview_csv` (rendered a Rich table) → `build_csv_preview` returning `(Table, has_header)`; the init wizard renders.
  - `.importlinter` now has only one acknowledged exception (`logging_config → ui.console`, unavoidable for the RichHandler wiring).
- **Service-layer tests.** Added `test_problem_service.py` (7 tests) and `test_team_service.py` (12 tests) covering happy-path, idempotency, partial failures in `create_many`, error wrapping, and group-id fallback. Brings the unit suite from 305 → 323.
- **Renamed `dom/utils/cli.py` → `dom/utils/project.py`.** It was never CLI-specific — it holds project-paths, container-prefix, secrets-manager construction. Test file renamed to match.
- **Removed `Service.entity_name()`.** Abstract method that was implemented by two services and never consumed polymorphically.
- **Added `CONTRIBUTING.md`** documenting the four-layer architecture (CLI → operations → services → infrastructure), the import-linter contracts, and a five-step end-to-end walkthrough for adding a new CLI command.

## Test plan

- [x] `make test` — 323 unit tests pass
- [x] `lint-imports` — all 3 contracts kept
- [x] `make lint` (ruff, ruff-format, bandit, lint-imports) — passes via pre-commit
- [x] `make typecheck` — mypy clean
- [ ] Manual smoke: \`dom infra apply\` on a privileged port still warns the user (now from CLI layer)
- [ ] Manual smoke: \`dom init\` CSV preview still renders during the team-import wizard