### PR TITLE
refactor(operations): contest apply uses Steps; service is a flat toolkit

### DIFF
--- a/dom/cli/contest/render.py
+++ b/dom/cli/contest/render.py
@@ -5,11 +5,9 @@ Keeping presentation here means the core layers stay free of console
 concerns.
 """
 
-from typing import Any
-
 from dom import ui
 from dom.core.services.contest.apply import ContestApplyResult
-from dom.core.services.contest.changes import ChangeType, ContestChangeSet
+from dom.core.services.contest.changes import ChangeType, ContestChangeSet, ContestPlan
 
 
 def format_contest_change_summary(change_set: ContestChangeSet) -> str:
@@ -22,8 +20,8 @@ def format_contest_change_summary(change_set: ContestChangeSet) -> str:
     return f"[yellow]UPDATE[/yellow] contest '{shortname}': {', '.join(parts)}"
 
 
-def render_planned_changes(changes: list[dict[str, Any]]) -> None:
-    if not changes:
+def render_planned_changes(plan: ContestPlan) -> None:
+    if not plan.items:
         ui.blank()
         ui.hint("No changes detected.")
         ui.blank()
@@ -37,8 +35,8 @@ def render_planned_changes(changes: list[dict[str, Any]]) -> None:
     any_resource_changes = False
     any_creates = False
 
-    for item in changes:
-        change_set = item["change_set"]
+    for item in plan.items:
+        change_set = item.change_set
 
         if change_set.change_type == ChangeType.CREATE:
             any_creates = True

--- a/dom/core/__init__.py
+++ b/dom/core/__init__.py
@@ -13,10 +13,13 @@ This package is split into two sublayers with a strict boundary:
 
 **`dom.core.services`** — declarative business logic.
     A *Service* knows HOW. It owns the API client / Docker client / secrets
-    interaction and exposes intent-named methods (``apply_contest``,
+    interaction and exposes a flat collection of intent-named, single-purpose
+    methods (``compare``, ``resolve_or_create``, ``provision_team_group``,
     ``start_service``, ``regenerate_compose``, ``check_status``, etc.).
-    Services may compose other services. Services MUST NOT import from
-    ``dom.core.operations`` or ``dom.cli`` (enforced by import-linter).
+    Services MUST NOT internally orchestrate multi-step workflows — that
+    belongs in operations. Services may compose other services and MUST NOT
+    import from ``dom.core.operations`` or ``dom.cli`` (enforced by
+    import-linter).
 
 The reference implementation of this split is the infrastructure pipeline:
 ``dom.core.services.infra.service.InfraService`` exposes all infrastructure

--- a/dom/core/operations/contest/apply.py
+++ b/dom/core/operations/contest/apply.py
@@ -1,12 +1,45 @@
-"""Apply contest configuration to the DOMjudge platform."""
+"""Apply contest configuration to the DOMjudge platform.
 
-from dom.core.operations.framework import Context, operation
+The operation expands each contest in the configuration into a fixed
+five-step workflow (compare → resolve-or-create → provision team
+group → apply problems → apply teams). Steps mutate a per-contest
+:class:`_ContestSession` via closures; the aggregate
+:class:`ContestApplyResult` list is built from those sessions and
+returned so the CLI can render any field-change warnings.
+"""
+
+from dataclasses import dataclass, field
+
+from dom.core.operations.framework import Context, Step, Steps, operation
 from dom.core.operations.wiring import wire_admin_api
+from dom.core.services.base import ServiceContext
 from dom.core.services.contest.apply import ContestApplicationService, ContestApplyResult
-from dom.core.services.contest.state import ContestStateComparator
+from dom.core.services.contest.changes import ContestChangeSet, FieldChange
 from dom.core.services.problem.apply import ProblemService
 from dom.core.services.team.apply import TeamService
-from dom.types.config.processed import DomConfig
+from dom.types.config.processed import ContestConfig, DomConfig
+
+
+@dataclass
+class _ContestSession:
+    """Per-contest state threaded across this contest's Steps via closures."""
+
+    config: ContestConfig
+    change_set: ContestChangeSet | None = None
+    contest_id: str | None = None
+    team_group_id: str | None = None
+    skipped_field_changes: list[FieldChange] = field(default_factory=list)
+
+    @property
+    def shortname(self) -> str:
+        return self.config.shortname or "?"
+
+    def to_result(self) -> ContestApplyResult:
+        return ContestApplyResult(
+            contest_shortname=self.shortname,
+            contest_id=self.contest_id or "",
+            skipped_field_changes=self.skipped_field_changes,
+        )
 
 
 def _summary(results: list[ContestApplyResult]) -> str:
@@ -19,21 +52,62 @@ def _summary(results: list[ContestApplyResult]) -> str:
     return f"Applied {len(results)} contests{suffix}"
 
 
-def _apply_all(config: DomConfig, ctx: Context) -> list[ContestApplyResult]:
-    """Wire dependencies once, then apply every contest through the service."""
+def _build_contest_steps(svc: ContestApplicationService, session: _ContestSession) -> list[Step]:
+    """Five named steps that together apply one contest."""
+    sn = session.shortname
+
+    def context() -> ServiceContext:
+        return ServiceContext(
+            client=svc.client,
+            contest_id=session.contest_id,
+            contest_shortname=sn,
+            team_group_id=session.team_group_id,
+        )
+
+    def compare_step() -> None:
+        session.change_set = svc.compare(session.config)
+
+    def resolve_step() -> None:
+        assert session.change_set is not None
+        contest_id, skipped = svc.resolve_or_create(session.config, session.change_set)
+        session.contest_id = contest_id
+        session.skipped_field_changes = skipped
+
+    def provision_step() -> None:
+        assert session.contest_id is not None
+        session.team_group_id = svc.provision_team_group(session.contest_id, sn)
+
+    def apply_problems_step() -> None:
+        svc.apply_problems(session.config, context())
+
+    def apply_teams_step() -> None:
+        svc.apply_teams(session.config, context())
+
+    return [
+        Step(f"[{sn}] Compare state", compare_step),
+        Step(f"[{sn}] Create or resolve", resolve_step),
+        Step(f"[{sn}] Provision team group", provision_step),
+        Step(f"[{sn}] Apply problems", apply_problems_step),
+        Step(f"[{sn}] Apply teams", apply_teams_step),
+    ]
+
+
+@operation("Apply contests", summary=_summary)
+def apply_contests_op(ctx: Context, config: DomConfig) -> Steps:
+    if not config.contests:
+        raise ValueError("No contests in configuration")
+
     client = wire_admin_api(config.infra, ctx.secrets)
-    service = ContestApplicationService(
+    svc = ContestApplicationService(
         client,
         ctx.secrets,
         problem_service=ProblemService(client),
         team_service=TeamService(client, ctx.secrets),
-        state_comparator=ContestStateComparator(client, ctx.secrets),
     )
-    return [service.apply_contest(contest) for contest in config.contests]
 
+    sessions = [_ContestSession(config=c) for c in config.contests]
+    steps: list[Step] = []
+    for session in sessions:
+        steps.extend(_build_contest_steps(svc, session))
 
-@operation("Apply contests", summary=_summary, show_progress=False)
-def apply_contests_op(ctx: Context, config: DomConfig) -> list[ContestApplyResult]:
-    if not config.contests:
-        raise ValueError("No contests in configuration")
-    return _apply_all(config, ctx)
+    return Steps(steps=steps, result=lambda: [s.to_result() for s in sessions])

--- a/dom/core/operations/contest/load_config.py
+++ b/dom/core/operations/contest/load_config.py
@@ -17,6 +17,4 @@ def _summary(config: DomConfig) -> str:
 
 @operation("Load configuration", summary=_summary)
 def load_config_op(ctx: Context, path: Path | None = None) -> DomConfig:
-    if path is not None and not path.exists():
-        raise FileNotFoundError(f"Configuration file not found: {path}")
     return load_config(path, ctx.secrets)

--- a/dom/core/operations/contest/load_contest_config.py
+++ b/dom/core/operations/contest/load_contest_config.py
@@ -16,6 +16,4 @@ def _summary(contest: ContestConfig) -> str:
 
 @operation("Load contest configuration", summary=_summary)
 def load_contest_config_op(ctx: Context, path: Path | None, contest_name: str) -> ContestConfig:
-    if path is not None and not path.exists():
-        raise FileNotFoundError(f"Configuration file not found: {path}")
     return load_contest_config(path, contest_name, ctx.secrets)

--- a/dom/core/operations/contest/plan_changes.py
+++ b/dom/core/operations/contest/plan_changes.py
@@ -1,24 +1,27 @@
 """Plan contest changes without applying them."""
 
-from typing import Any
-
 from dom.core.operations.framework import Context, operation
 from dom.core.operations.wiring import wire_admin_api
+from dom.core.services.contest.changes import ContestPlan, ContestPlanItem
 from dom.core.services.contest.state import ContestStateComparator
 from dom.types.config.processed import DomConfig
 
 
-def _summary(changes: list[dict[str, Any]]) -> str:
-    total = sum(1 for item in changes if item["change_set"].has_changes)
-    return f"Analyzed {len(changes)} contest(s) • {total} with changes"
+def _summary(plan: ContestPlan) -> str:
+    return f"Analyzed {len(plan.items)} contest(s) • {plan.changed_count} with changes"
 
 
 @operation("Plan contest changes", summary=_summary, show_progress=False)
-def plan_contest_changes_op(ctx: Context, config: DomConfig) -> list[dict[str, Any]]:
+def plan_contest_changes_op(ctx: Context, config: DomConfig) -> ContestPlan:
     """Compute per-contest change sets. Rendering is the CLI's job."""
     client = wire_admin_api(config.infra, ctx.secrets)
     comparator = ContestStateComparator(client, ctx.secrets)
-    return [
-        {"shortname": contest.shortname, "change_set": comparator.compare_contest(contest)}
-        for contest in config.contests
-    ]
+    return ContestPlan(
+        items=[
+            ContestPlanItem(
+                shortname=contest.shortname or "?",
+                change_set=comparator.compare_contest(contest),
+            )
+            for contest in config.contests
+        ]
+    )

--- a/dom/core/operations/contest/verify_problemset.py
+++ b/dom/core/operations/contest/verify_problemset.py
@@ -20,11 +20,6 @@ def verify_problemset_op(
     contest_name: str,
     infra_config_path: Path | None = None,
 ) -> ContestConfig:
-    if config_path is not None and not config_path.exists():
-        raise FileNotFoundError(f"Configuration file not found: {config_path}")
-    if infra_config_path is not None and not infra_config_path.exists():
-        raise FileNotFoundError(f"Infrastructure config file not found: {infra_config_path}")
-
     contest = load_contest_config(config_path, contest_name, ctx.secrets)
     infra = load_infrastructure_config(infra_config_path)
     client = wire_admin_api(infra, ctx.secrets)

--- a/dom/core/operations/framework.py
+++ b/dom/core/operations/framework.py
@@ -71,10 +71,19 @@ class Step:
 
 @dataclass(frozen=True)
 class Steps:
-    """Multi-step plan with an optional final success message."""
+    """Multi-step plan with an optional final success message.
+
+    Multi-step operations normally return ``None``. When a :class:`Steps`
+    plan provides ``result``, the runner calls it after all steps finish
+    and forwards the value as the operation's return — so multi-step ops
+    can produce a typed result (e.g. an aggregate built up by step
+    closures) and their ``@operation(summary=...)`` callback can format it
+    just like a single-step op.
+    """
 
     steps: list[Step] = field(default_factory=list)
     summary: str = ""
+    result: Callable[[], Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -234,9 +243,11 @@ def run(
             _execute_steps(r, op.label, plan.steps, op.show_progress, ctx.verbose)
         except Exception as exc:
             _fail(r, op.label, exc)
-        r.success(op.label, plan.summary)
+        value = plan.result() if plan.result is not None else None
+        message = _resolve_summary(op, value) if value is not None else plan.summary
+        r.success(op.label, message)
         logger.info(f"Operation completed: {op.label}", extra={"operation": op.label})
-        return None
+        return value
 
     message = _resolve_summary(op, plan.value)
     r.success(op.label, message)

--- a/dom/core/operations/infrastructure/load_config.py
+++ b/dom/core/operations/infrastructure/load_config.py
@@ -13,6 +13,4 @@ def _summary(config: InfraConfig) -> str:
 
 @operation("Load infrastructure configuration", summary=_summary)
 def load_infra_config_op(_ctx: Context, path: Path | None = None) -> InfraConfig:
-    if path is not None and not path.exists():
-        raise FileNotFoundError(f"Configuration file not found: {path}")
     return load_infrastructure_config(path)

--- a/dom/core/services/contest/apply.py
+++ b/dom/core/services/contest/apply.py
@@ -1,12 +1,19 @@
-"""Declarative contest application service.
+"""Contest application toolkit.
 
-The orchestrator (:meth:`ContestApplicationService.apply_contest`) reads
-top-down as a sequence of named steps. Each step is implemented as a
-small, single-purpose private method below the orchestrator.
+This service is intentionally a flat collection of single-purpose
+methods. The orchestration that turns these methods into a workflow
+lives one layer up, in :mod:`dom.core.operations.contest.apply`, where
+each step is named and executed via the operations framework. Keeping
+the orchestration there gives the user step-by-step progress, useful
+``--dry-run`` listings, and a single place to read the contest-apply
+flow.
+
+The DOMjudge API does not support contest updates, so when a contest
+already exists with different fields the deltas are surfaced via
+:class:`ContestApplyResult.skipped_field_changes` rather than applied.
+Resource reconciliation (problems, teams) is always idempotent.
 """
 
-from collections.abc import Callable
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 
 from dom.core.services.base import ServiceContext
@@ -30,8 +37,7 @@ class ContestApplyResult:
 
     ``skipped_field_changes`` lists field deltas that were detected on an
     existing contest but could not be applied (DOMjudge API does not
-    support contest updates). The CLI layer renders these to the user;
-    the service stays free of presentation concerns.
+    support contest updates). The CLI layer renders these to the user.
     """
 
     contest_shortname: str
@@ -39,14 +45,24 @@ class ContestApplyResult:
     skipped_field_changes: list[FieldChange] = field(default_factory=list)
 
 
-class ContestApplicationService:
-    """Declarative service for applying contest configurations.
+def _team_group_naming(shortname: str) -> tuple[str, str]:
+    """Return ``(group_name, group_id)`` for a contest's scoreboard team group."""
+    return f"{shortname.upper()} Teams", f"{shortname}-teams"
 
-    Idempotent and intended for INITIAL SETUP only. The DOMjudge API
-    does not support contest updates: if a contest already exists with
-    different fields, the deltas are surfaced via
-    :class:`ContestApplyResult.skipped_field_changes` rather than applied.
-    Resources (problems, teams) are always reconciled idempotently.
+
+def _require_shortname(contest: ContestConfig) -> str:
+    """Treat shortname as a precondition. Loaders must guarantee it."""
+    if contest.shortname is None:
+        raise ContestError("Contest configuration is missing required 'shortname'")
+    return contest.shortname
+
+
+class ContestApplicationService:
+    """Toolkit for applying contest configurations.
+
+    Each public method corresponds to one step of the contest-apply
+    workflow. The operations layer composes these into a named, ordered
+    plan; this class never orchestrates them itself.
     """
 
     def __init__(
@@ -64,59 +80,25 @@ class ContestApplicationService:
         self.team_service = team_service or TeamService(client, secrets)
         self.state_comparator = state_comparator or ContestStateComparator(client, secrets)
 
-    # ------------------------------------------------------------------ public
-
-    def apply_contest(self, contest: ContestConfig) -> ContestApplyResult:
-        """Apply a single contest configuration.
-
-        Reads top-down as a sequence of steps:
-        compare → create-or-resolve → provision team group → apply resources.
-        """
-        shortname = _require_shortname(contest)
-        logger.info(
-            "Applying contest configuration",
-            extra={"contest_name": contest.name, "contest_shortname": shortname},
-        )
-
-        change_set = self.state_comparator.compare_contest(contest)
-        contest_id, skipped = self._resolve_or_create(contest, change_set)
-        team_group_id = self._provision_team_group(contest_id, shortname)
-
-        self._apply_resources(
-            contest,
-            ServiceContext(
-                client=self.client,
-                contest_id=contest_id,
-                contest_shortname=shortname,
-                team_group_id=team_group_id,
-            ),
-        )
-
-        logger.info(
-            f"Successfully configured contest '{shortname}'",
-            extra={
-                "contest_id": contest_id,
-                "contest_shortname": shortname,
-                "problems_count": len(contest.problems),
-                "teams_count": len(contest.teams),
-            },
-        )
-        return ContestApplyResult(
-            contest_shortname=shortname,
-            contest_id=contest_id,
-            skipped_field_changes=skipped,
-        )
-
     # ------------------------------------------------------------------ steps
 
-    def _resolve_or_create(
+    def compare(self, contest: ContestConfig) -> ContestChangeSet:
+        """Compare desired vs. current contest state."""
+        shortname = _require_shortname(contest)
+        logger.info(
+            "Comparing contest state",
+            extra={"contest_name": contest.name, "contest_shortname": shortname},
+        )
+        return self.state_comparator.compare_contest(contest)
+
+    def resolve_or_create(
         self, contest: ContestConfig, change_set: ContestChangeSet
     ) -> tuple[str, list[FieldChange]]:
-        """Return ``(contest_id, skipped_field_changes)`` for the contest.
+        """Return ``(contest_id, skipped_field_changes)``.
 
         Creates a new contest when the change set says so; otherwise
-        resolves the existing one and reports any field deltas that
-        cannot be applied via the API.
+        uses ``change_set.existing_contest_id`` and reports any field
+        deltas that cannot be applied via the API.
         """
         shortname = change_set.contest_shortname
 
@@ -125,7 +107,11 @@ class ContestApplicationService:
             logger.info(f"✓ Created new contest '{shortname}' (ID: {contest_id})")
             return contest_id, []
 
-        contest_id = self._resolve_existing_contest_id(shortname)
+        if change_set.existing_contest_id is None:
+            raise ContestError(
+                f"Contest '{shortname}' was expected to exist but no id was resolved"
+            )
+        contest_id = change_set.existing_contest_id
 
         if not change_set.field_changes:
             logger.info(f"✓ Contest '{shortname}' exists with no field changes")
@@ -141,13 +127,30 @@ class ContestApplicationService:
         )
         return contest_id, skipped
 
-    def _resolve_existing_contest_id(self, shortname: str) -> str:
-        current = self.state_comparator._fetch_current_contest(shortname)
-        if current is None:
-            raise ContestError(
-                f"Contest '{shortname}' was expected to exist but could not be fetched"
-            )
-        return str(current["id"])
+    def provision_team_group(self, contest_id: str, shortname: str) -> str:
+        """Create the contest-specific team group used for scoreboard filtering."""
+        group_name, group_id = _team_group_naming(shortname)
+        result = self.client.groups.create_for_contest(
+            contest_id=contest_id, name=group_name, group_id=group_id
+        )
+        logger.info(f"Created team group '{group_name}' (ID: {result.id}) for contest {shortname}")
+        return str(result.id)
+
+    def apply_problems(self, contest: ContestConfig, context: ServiceContext) -> None:
+        """Add the contest's problems via :class:`ProblemService`."""
+        results = self.problem_service.create_many(contest.problems, context, stop_on_error=False)
+        summary = self.problem_service.get_summary(results)
+        if summary["failed"] > 0:
+            raise ContestError(f"{summary['failed']} problem(s) failed to add")
+
+    def apply_teams(self, contest: ContestConfig, context: ServiceContext) -> None:
+        """Add the contest's teams via :class:`TeamService`."""
+        results = self.team_service.create_many(contest.teams, context, stop_on_error=False)
+        summary = self.team_service.get_summary(results)
+        if summary["failed"] > 0:
+            raise ContestError(f"{summary['failed']} team(s) failed to add")
+
+    # ------------------------------------------------------------------ helpers
 
     def _create_contest(self, contest: ContestConfig) -> str:
         shortname = _require_shortname(contest)
@@ -180,80 +183,3 @@ class ContestApplicationService:
             },
         )
         return str(result.id)
-
-    def _provision_team_group(self, contest_id: str, shortname: str) -> str:
-        """Create the contest-specific team group used for scoreboard filtering."""
-        group_name = f"{shortname.upper()} Teams"
-        result = self.client.groups.create_for_contest(
-            contest_id=contest_id, name=group_name, group_id=f"{shortname}-teams"
-        )
-        logger.info(f"Created team group '{group_name}' (ID: {result.id}) for contest {shortname}")
-        return str(result.id)
-
-    def _apply_resources(self, contest: ContestConfig, context: ServiceContext) -> None:
-        """Apply problems and teams concurrently, collecting any failures."""
-        tasks: dict[str, Callable[[], None]] = {
-            "problems": lambda: self._apply_problems(contest.problems, context),
-            "teams": lambda: self._apply_teams(contest.teams, context),
-        }
-        failures = _run_concurrent(tasks, context, contest.shortname or "?")
-        if failures:
-            details = ", ".join(f"{name}: {exc!s}" for name, exc in failures)
-            raise ContestError(
-                f"Failed to fully configure contest '{contest.shortname}': {details}"
-            )
-
-    def _apply_problems(self, problems, context: ServiceContext) -> None:
-        results = self.problem_service.create_many(problems, context, stop_on_error=False)
-        summary = self.problem_service.get_summary(results)
-        if summary["failed"] > 0:
-            raise ContestError(f"{summary['failed']} problem(s) failed to add")
-
-    def _apply_teams(self, teams, context: ServiceContext) -> None:
-        results = self.team_service.create_many(teams, context, stop_on_error=False)
-        summary = self.team_service.get_summary(results)
-        if summary["failed"] > 0:
-            raise ContestError(f"{summary['failed']} team(s) failed to add")
-
-
-# ---------------------------------------------------------------- helpers
-
-
-def _require_shortname(contest: ContestConfig) -> str:
-    """Treat shortname as a precondition. Loaders must guarantee it."""
-    if contest.shortname is None:
-        raise ContestError("Contest configuration is missing required 'shortname'")
-    return contest.shortname
-
-
-def _run_concurrent(
-    tasks: dict[str, Callable[[], None]],
-    context: ServiceContext,
-    contest_shortname: str,
-) -> list[tuple[str, Exception]]:
-    """Run named tasks in parallel, returning ``(name, exc)`` for each failure.
-
-    All tasks run to completion even if some fail, so the caller sees
-    every problem at once instead of fixing them one round-trip at a time.
-    """
-    failures: list[tuple[str, Exception]] = []
-    with ThreadPoolExecutor(max_workers=len(tasks)) as executor:
-        futures = {executor.submit(fn): name for name, fn in tasks.items()}
-        for future in as_completed(futures):
-            name = futures[future]
-            try:
-                future.result()
-            except Exception as exc:
-                logger.error(
-                    f"Failed to apply {name} for contest {contest_shortname}",
-                    exc_info=True,
-                    extra={
-                        "task": name,
-                        "contest_shortname": contest_shortname,
-                        "contest_id": context.contest_id,
-                    },
-                )
-                failures.append((name, exc))
-            else:
-                logger.info(f"Successfully applied {name} for contest {contest_shortname}")
-    return failures

--- a/dom/core/services/contest/changes.py
+++ b/dom/core/services/contest/changes.py
@@ -4,7 +4,7 @@ Kept separate from the comparator service so callers can consume the change
 shapes without depending on the comparison logic.
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any
 
@@ -58,12 +58,19 @@ class ResourceChange:
 
 @dataclass
 class ContestChangeSet:
-    """Represents all detected changes for a contest."""
+    """Represents all detected changes for a contest.
+
+    ``existing_contest_id`` is set by the comparator when a contest was
+    found on the platform (i.e. ``change_type`` is ``UPDATE`` or
+    ``NO_CHANGE``); it lets the apply path resolve the contest without
+    re-fetching the listing.
+    """
 
     contest_shortname: str
     change_type: ChangeType
     field_changes: list[FieldChange]
     resource_changes: list[ResourceChange]
+    existing_contest_id: str | None = None
 
     @property
     def has_changes(self) -> bool:
@@ -92,3 +99,22 @@ class ContestChangeSet:
             if rc.has_changes:
                 parts.append(rc.resource_type)
         return self.change_type, self.contest_shortname, parts
+
+
+@dataclass(frozen=True)
+class ContestPlanItem:
+    """One contest's planned change set, returned by the plan operation."""
+
+    shortname: str
+    change_set: ContestChangeSet
+
+
+@dataclass(frozen=True)
+class ContestPlan:
+    """Aggregate plan across all contests in a configuration."""
+
+    items: list[ContestPlanItem] = field(default_factory=list)
+
+    @property
+    def changed_count(self) -> int:
+        return sum(1 for item in self.items if item.change_set.has_changes)

--- a/dom/core/services/contest/state.py
+++ b/dom/core/services/contest/state.py
@@ -142,7 +142,7 @@ class ContestStateComparator:
             )
 
         field_changes = self._diff_fields(desired, current)
-        contest_id = current["id"]
+        contest_id = str(current["id"])
         return ContestChangeSet(
             contest_shortname=shortname,
             change_type=ChangeType.UPDATE if field_changes else ChangeType.NO_CHANGE,
@@ -151,6 +151,7 @@ class ContestStateComparator:
                 self._diff_problems(desired, contest_id),
                 self._diff_teams(desired, contest_id),
             ],
+            existing_contest_id=contest_id,
         )
 
     # ------------------------------------------------------------------ fetch

--- a/tests/unit/operations/test_contest_operations.py
+++ b/tests/unit/operations/test_contest_operations.py
@@ -11,6 +11,12 @@ from dom.core.operations.contest.load_config import load_config_op
 from dom.core.operations.contest.load_contest_config import load_contest_config_op
 from dom.core.operations.contest.plan_changes import plan_contest_changes_op
 from dom.core.operations.contest.verify_problemset import verify_problemset_op
+from dom.core.services.contest.changes import (
+    ChangeType,
+    ContestChangeSet,
+    ContestPlan,
+    ContestPlanItem,
+)
 from dom.types.secrets import SecretsProvider
 
 
@@ -36,26 +42,48 @@ def _make_dom_config(num_contests: int = 1, problems: int = 2, teams: int = 3):
 # ---------------------------------------------------------------- ApplyContests
 
 
-def _result(shortname="C0", skipped=()):
-    from dom.core.services.contest.apply import ContestApplyResult
+def _stub_service(skipped_per_contest: dict[str, list] | None = None):
+    """Service stub whose toolkit methods record per-contest state.
 
-    return ContestApplyResult(
-        contest_shortname=shortname,
-        contest_id=f"id-{shortname}",
-        skipped_field_changes=list(skipped),
+    Returns ``(svc, calls)`` where ``calls`` is the per-method invocation log.
+    """
+    skipped_per_contest = skipped_per_contest or {}
+    svc = MagicMock()
+    svc.client = MagicMock()
+    svc.compare.side_effect = lambda contest: ContestChangeSet(
+        contest_shortname=contest.shortname,
+        change_type=ChangeType.CREATE,
+        field_changes=[],
+        resource_changes=[],
     )
+    svc.resolve_or_create.side_effect = lambda contest, _cs: (
+        f"id-{contest.shortname}",
+        skipped_per_contest.get(contest.shortname, []),
+    )
+    svc.provision_team_group.side_effect = lambda contest_id, _sn: f"group-{contest_id}"
+    svc.apply_problems.return_value = None
+    svc.apply_teams.return_value = None
+    return svc
 
 
-def test_apply_runs_service_and_returns_results(context):
-    config = _make_dom_config()
-    with patch(
-        "dom.core.operations.contest.apply._apply_all",
-        return_value=[_result("C0")],
-    ) as svc:
-        result = run(apply_contests_op(config), context)
-    svc.assert_called_once_with(config, context)
-    assert len(result) == 1
-    assert result[0].contest_shortname == "C0"
+def test_apply_runs_five_steps_per_contest(context):
+    config = _make_dom_config(num_contests=2)
+    svc = _stub_service()
+    with (
+        patch("dom.core.operations.contest.apply.wire_admin_api"),
+        patch("dom.core.operations.contest.apply.ContestApplicationService", return_value=svc),
+        patch("dom.core.operations.contest.apply.ProblemService"),
+        patch("dom.core.operations.contest.apply.TeamService"),
+    ):
+        results = run(apply_contests_op(config), context)
+
+    assert svc.compare.call_count == 2
+    assert svc.resolve_or_create.call_count == 2
+    assert svc.provision_team_group.call_count == 2
+    assert svc.apply_problems.call_count == 2
+    assert svc.apply_teams.call_count == 2
+    assert [r.contest_shortname for r in results] == ["C0", "C1"]
+    assert [r.contest_id for r in results] == ["id-C0", "id-C1"]
 
 
 def test_apply_rejects_empty_contests(context):
@@ -66,20 +94,31 @@ def test_apply_rejects_empty_contests(context):
 
 def test_apply_summary_for_single_contest(context, capsys):
     config = _make_dom_config(num_contests=1)
-    with patch(
-        "dom.core.operations.contest.apply._apply_all",
-        return_value=[_result("C0")],
+    with (
+        patch("dom.core.operations.contest.apply.wire_admin_api"),
+        patch(
+            "dom.core.operations.contest.apply.ContestApplicationService",
+            return_value=_stub_service(),
+        ),
+        patch("dom.core.operations.contest.apply.ProblemService"),
+        patch("dom.core.operations.contest.apply.TeamService"),
     ):
         run(apply_contests_op(config), context)
     out = capsys.readouterr().out
     assert "C0" in out
+    assert "Applied" in out
 
 
 def test_apply_summary_for_multiple_contests(context, capsys):
     config = _make_dom_config(num_contests=2)
-    with patch(
-        "dom.core.operations.contest.apply._apply_all",
-        return_value=[_result("C0"), _result("C1")],
+    with (
+        patch("dom.core.operations.contest.apply.wire_admin_api"),
+        patch(
+            "dom.core.operations.contest.apply.ContestApplicationService",
+            return_value=_stub_service(),
+        ),
+        patch("dom.core.operations.contest.apply.ProblemService"),
+        patch("dom.core.operations.contest.apply.TeamService"),
     ):
         run(apply_contests_op(config), context)
     out = capsys.readouterr().out
@@ -91,21 +130,39 @@ def test_apply_summary_flags_skipped_field_changes(context, capsys):
 
     config = _make_dom_config(num_contests=1)
     skipped = [FieldChange(field="duration", old_value="5:00", new_value="6:00")]
-    with patch(
-        "dom.core.operations.contest.apply._apply_all",
-        return_value=[_result("C0", skipped=skipped)],
+    with (
+        patch("dom.core.operations.contest.apply.wire_admin_api"),
+        patch(
+            "dom.core.operations.contest.apply.ContestApplicationService",
+            return_value=_stub_service(skipped_per_contest={"C0": skipped}),
+        ),
+        patch("dom.core.operations.contest.apply.ProblemService"),
+        patch("dom.core.operations.contest.apply.TeamService"),
     ):
         run(apply_contests_op(config), context)
     out = capsys.readouterr().out
     assert "skipped" in out
 
 
+def test_apply_op_is_multi_step_with_summary_callback(context):
+    """apply_contests_op now returns Steps; framework forwards the result."""
+    config = _make_dom_config()
+    op = apply_contests_op(config)
+    assert op.summary is not None
+    assert op.show_progress is True
+
+
 # ---------------------------------------------------------------- PlanChanges
 
 
-def test_plan_returns_per_contest_change_sets(context):
+def test_plan_returns_typed_plan_with_one_item_per_contest(context):
     config = _make_dom_config(num_contests=2)
-    fake_change = MagicMock(has_changes=True)
+    fake_change = ContestChangeSet(
+        contest_shortname="C",
+        change_type=ChangeType.CREATE,
+        field_changes=[],
+        resource_changes=[],
+    )
 
     with (
         patch("dom.core.operations.contest.plan_changes.wire_admin_api"),
@@ -114,13 +171,28 @@ def test_plan_returns_per_contest_change_sets(context):
         comparator_cls.return_value.compare_contest.return_value = fake_change
         result = run(plan_contest_changes_op(config), context)
 
-    assert len(result) == 2
-    assert all(item["change_set"] is fake_change for item in result)
+    assert isinstance(result, ContestPlan)
+    assert len(result.items) == 2
+    assert all(isinstance(item, ContestPlanItem) for item in result.items)
+    assert all(item.change_set is fake_change for item in result.items)
 
 
 def test_plan_summary_counts_changes(context, capsys):
     config = _make_dom_config(num_contests=2)
-    changes = [MagicMock(has_changes=True), MagicMock(has_changes=False)]
+    changes = [
+        ContestChangeSet(
+            contest_shortname="C0",
+            change_type=ChangeType.CREATE,
+            field_changes=[],
+            resource_changes=[],
+        ),
+        ContestChangeSet(
+            contest_shortname="C1",
+            change_type=ChangeType.NO_CHANGE,
+            field_changes=[],
+            resource_changes=[],
+        ),
+    ]
 
     with (
         patch("dom.core.operations.contest.plan_changes.wire_admin_api"),
@@ -132,26 +204,26 @@ def test_plan_summary_counts_changes(context, capsys):
     assert "1 with changes" in capsys.readouterr().out
 
 
-def test_render_planned_changes_handles_no_changes(capsys):
+def test_render_planned_changes_handles_empty_plan(capsys):
     from dom.cli.contest.render import render_planned_changes
 
-    render_planned_changes([])
+    render_planned_changes(ContestPlan())
     output = capsys.readouterr().out
     assert "No changes" in output
 
 
 def test_render_planned_changes_renders_creates(capsys):
     from dom.cli.contest.render import render_planned_changes
-    from dom.core.services.contest.changes import ChangeType
 
-    change_set = MagicMock(
+    cs = ContestChangeSet(
+        contest_shortname="C0",
         change_type=ChangeType.CREATE,
         field_changes=[],
         resource_changes=[],
     )
-    change_set.summary_parts.return_value = (ChangeType.CREATE, "C0", [])
+    plan = ContestPlan(items=[ContestPlanItem(shortname="C0", change_set=cs)])
 
-    render_planned_changes([{"shortname": "C0", "change_set": change_set}])
+    render_planned_changes(plan)
     output = capsys.readouterr().out
     assert "Planned Changes" in output
     assert "C0" in output
@@ -275,12 +347,3 @@ def test_verify_rejects_missing_files(context, tmp_path):
     missing_infra = tmp_path / "i.yaml"
     with pytest.raises(typer.Exit):
         run(verify_problemset_op(missing_contest, "ContestA", missing_infra), context)
-
-
-def test_apply_op_is_single_step_with_summary_callback(context):
-    """apply_contests_op is a single-step op returning ContestApplyResult list."""
-    config = _make_dom_config()
-    op = apply_contests_op(config)
-    assert op.summary is not None
-    # Single-step ops auto-wrap their return; show_progress is disabled.
-    assert op.show_progress is False

--- a/tests/unit/services/test_contest_apply.py
+++ b/tests/unit/services/test_contest_apply.py
@@ -1,11 +1,21 @@
-"""Tests for ContestApplicationService."""
+"""Tests for ContestApplicationService.
 
-from unittest.mock import MagicMock, patch
+The service is a flat toolkit — orchestration lives in
+``dom.core.operations.contest.apply``. These tests exercise each
+toolkit method in isolation.
+"""
+
+from unittest.mock import MagicMock
 
 import pytest
 
+from dom.core.services.base import ServiceContext
 from dom.core.services.contest.apply import ContestApplicationService
-from dom.core.services.contest.changes import ChangeType
+from dom.core.services.contest.changes import (
+    ChangeType,
+    ContestChangeSet,
+    FieldChange,
+)
 from dom.exceptions import ContestError
 from dom.types.secrets import SecretsProvider
 
@@ -17,7 +27,6 @@ def secrets():
 
 @pytest.fixture
 def client():
-    """API client with the call paths used by ContestApplicationService."""
     c = MagicMock()
     c.contests.create.return_value = MagicMock(id="contest-1", created=True)
     c.groups.create_for_contest.return_value = MagicMock(id="group-1")
@@ -25,31 +34,28 @@ def client():
 
 
 @pytest.fixture
-def service(client, secrets):
-    """ContestApplicationService with all collaborators stubbed."""
-    with (
-        patch("dom.core.services.contest.apply.ProblemService") as ps_cls,
-        patch("dom.core.services.contest.apply.TeamService") as ts_cls,
-        patch("dom.core.services.contest.apply.ContestStateComparator") as cmp_cls,
-    ):
-        problem_service = MagicMock()
-        problem_service.create_many.return_value = []
-        problem_service.get_summary.return_value = {"failed": 0, "succeeded": 0}
-        ps_cls.return_value = problem_service
+def collaborators():
+    problem = MagicMock()
+    problem.create_many.return_value = []
+    problem.get_summary.return_value = {"failed": 0, "successful": 0}
+    team = MagicMock()
+    team.create_many.return_value = []
+    team.get_summary.return_value = {"failed": 0, "successful": 0}
+    comparator = MagicMock()
+    return problem, team, comparator
 
-        team_service = MagicMock()
-        team_service.create_many.return_value = []
-        team_service.get_summary.return_value = {"failed": 0, "succeeded": 0}
-        ts_cls.return_value = team_service
 
-        comparator = MagicMock()
-        cmp_cls.return_value = comparator
-
-        svc = ContestApplicationService(client, secrets)
-        svc._problem_mock = problem_service  # type: ignore[attr-defined]
-        svc._team_mock = team_service  # type: ignore[attr-defined]
-        svc._comparator_mock = comparator  # type: ignore[attr-defined]
-        yield svc
+@pytest.fixture
+def service(client, secrets, collaborators):
+    problem, team, comparator = collaborators
+    svc = ContestApplicationService(
+        client,
+        secrets,
+        problem_service=problem,
+        team_service=team,
+        state_comparator=comparator,
+    )
+    return svc
 
 
 def _contest(shortname="C0", name="Contest 0", problems=None, teams=None):
@@ -65,70 +71,145 @@ def _contest(shortname="C0", name="Contest 0", problems=None, teams=None):
     return c
 
 
-def _change_set(change_type=ChangeType.CREATE, field_changes=None):
-    cs = MagicMock()
-    cs.change_type = change_type
-    cs.field_changes = field_changes or []
-    return cs
+def _change_set(change_type=ChangeType.CREATE, field_changes=None, existing_id=None):
+    return ContestChangeSet(
+        contest_shortname="C0",
+        change_type=change_type,
+        field_changes=field_changes or [],
+        resource_changes=[],
+        existing_contest_id=existing_id,
+    )
 
 
-# ---------------------------------------------------------------- apply_contest
+# ---------------------------------------------------------------- compare
 
 
-def test_apply_contest_creates_when_change_type_is_create(service, client):
-    service._comparator_mock.compare_contest.return_value = _change_set(ChangeType.CREATE)
-    contest = _contest()
+def test_compare_delegates_to_state_comparator(service, collaborators):
+    _, _, comparator = collaborators
+    expected = _change_set()
+    comparator.compare_contest.return_value = expected
 
-    result = service.apply_contest(contest)
+    result = service.compare(_contest())
 
-    assert result.contest_id == "contest-1"
-    assert result.contest_shortname == "C0"
-    assert result.skipped_field_changes == []
+    assert result is expected
+    comparator.compare_contest.assert_called_once()
+
+
+def test_compare_requires_shortname(service):
+    contest = _contest(shortname=None)
+    with pytest.raises(ContestError, match="shortname"):
+        service.compare(contest)
+
+
+# ---------------------------------------------------------------- resolve_or_create
+
+
+def test_resolve_or_create_creates_new_contest(service, client):
+    cs = _change_set(ChangeType.CREATE)
+    contest_id, skipped = service.resolve_or_create(_contest(), cs)
+
+    assert contest_id == "contest-1"
+    assert skipped == []
     client.contests.create.assert_called_once()
     create_arg = client.contests.create.call_args.kwargs["contest_data"]
     assert create_arg.shortname == "C0"
 
 
-def test_apply_contest_skips_creation_when_no_change(service, client):
-    service._comparator_mock.compare_contest.return_value = _change_set(ChangeType.NO_CHANGE)
-    service._comparator_mock._fetch_current_contest.return_value = {"id": "existing-1"}
-    contest = _contest()
+def test_resolve_or_create_uses_existing_id_with_no_changes(service, client):
+    cs = _change_set(ChangeType.NO_CHANGE, existing_id="existing-1")
+    contest_id, skipped = service.resolve_or_create(_contest(), cs)
 
-    result = service.apply_contest(contest)
-
-    assert result.contest_id == "existing-1"
-    assert result.skipped_field_changes == []
+    assert contest_id == "existing-1"
+    assert skipped == []
     client.contests.create.assert_not_called()
 
 
-def test_apply_contest_returns_skipped_field_changes(service):
-    from dom.core.services.contest.changes import FieldChange
-
+def test_resolve_or_create_returns_skipped_field_changes(service):
     fc = FieldChange(field="duration", old_value="5:00", new_value="6:00")
-    service._comparator_mock.compare_contest.return_value = _change_set(
-        ChangeType.NO_CHANGE, field_changes=[fc]
-    )
-    service._comparator_mock._fetch_current_contest.return_value = {"id": "existing-1"}
+    cs = _change_set(ChangeType.UPDATE, field_changes=[fc], existing_id="existing-1")
 
-    result = service.apply_contest(_contest())
+    contest_id, skipped = service.resolve_or_create(_contest(), cs)
 
-    assert result.skipped_field_changes == [fc]
+    assert contest_id == "existing-1"
+    assert skipped == [fc]
 
 
-def test_apply_contest_accepts_injected_collaborators(client, secrets):
-    """Constructor injection: passing services directly bypasses module-level patches."""
-    from unittest.mock import MagicMock
+def test_resolve_or_create_raises_when_existing_id_missing(service):
+    cs = _change_set(ChangeType.UPDATE, existing_id=None)
+    with pytest.raises(ContestError, match="no id was resolved"):
+        service.resolve_or_create(_contest(), cs)
 
-    from dom.core.services.contest.apply import ContestApplicationService
 
-    problem = MagicMock()
-    problem.create_many.return_value = []
-    problem.get_summary.return_value = {"failed": 0}
-    team = MagicMock()
-    team.create_many.return_value = []
-    team.get_summary.return_value = {"failed": 0}
-    comparator = MagicMock()
-    comparator.compare_contest.return_value = _change_set(ChangeType.CREATE)
+def test_resolve_or_create_wraps_create_error_as_contest_error(service, client):
+    client.contests.create.side_effect = RuntimeError("upstream 500")
+    cs = _change_set(ChangeType.CREATE)
+
+    with pytest.raises(ContestError) as exc_info:
+        service.resolve_or_create(_contest(), cs)
+    assert "upstream 500" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------- provision_team_group
+
+
+def test_provision_team_group_uses_contest_naming(service, client):
+    group_id = service.provision_team_group("contest-1", "finals")
+
+    assert group_id == "group-1"
+    kwargs = client.groups.create_for_contest.call_args.kwargs
+    assert kwargs["contest_id"] == "contest-1"
+    assert kwargs["group_id"] == "finals-teams"
+    assert "FINALS" in kwargs["name"]
+
+
+# ---------------------------------------------------------------- apply_problems / apply_teams
+
+
+def _ctx(client):
+    return ServiceContext(client=client, contest_id="contest-1", contest_shortname="C0")
+
+
+def test_apply_problems_invokes_service(service, collaborators, client):
+    problem, _, _ = collaborators
+    contest = _contest(problems=["p1", "p2"])
+
+    service.apply_problems(contest, _ctx(client))
+
+    problem.create_many.assert_called_once()
+    assert problem.create_many.call_args.args[0] == ["p1", "p2"]
+
+
+def test_apply_problems_raises_on_failure(service, collaborators, client):
+    problem, _, _ = collaborators
+    problem.get_summary.return_value = {"failed": 2, "successful": 1}
+
+    with pytest.raises(ContestError):
+        service.apply_problems(_contest(), _ctx(client))
+
+
+def test_apply_teams_invokes_service(service, collaborators, client):
+    _, team, _ = collaborators
+    contest = _contest(teams=["t1", "t2", "t3"])
+
+    service.apply_teams(contest, _ctx(client))
+
+    team.create_many.assert_called_once()
+    assert team.create_many.call_args.args[0] == ["t1", "t2", "t3"]
+
+
+def test_apply_teams_raises_on_failure(service, collaborators, client):
+    _, team, _ = collaborators
+    team.get_summary.return_value = {"failed": 1, "successful": 0}
+
+    with pytest.raises(ContestError):
+        service.apply_teams(_contest(), _ctx(client))
+
+
+# ---------------------------------------------------------------- constructor injection
+
+
+def test_constructor_injection_wires_collaborators(client, secrets, collaborators):
+    problem, team, comparator = collaborators
 
     svc = ContestApplicationService(
         client,
@@ -141,93 +222,3 @@ def test_apply_contest_accepts_injected_collaborators(client, secrets):
     assert svc.problem_service is problem
     assert svc.team_service is team
     assert svc.state_comparator is comparator
-
-    result = svc.apply_contest(_contest())
-    assert result.contest_id == "contest-1"
-
-
-def test_apply_contest_creates_team_group_for_scoreboard(service, client):
-    service._comparator_mock.compare_contest.return_value = _change_set(ChangeType.CREATE)
-    contest = _contest(shortname="finals")
-
-    service.apply_contest(contest)
-
-    client.groups.create_for_contest.assert_called_once()
-    kwargs = client.groups.create_for_contest.call_args.kwargs
-    assert kwargs["group_id"] == "finals-teams"
-    assert "FINALS" in kwargs["name"]
-
-
-def test_apply_contest_invokes_problem_and_team_services(service):
-    service._comparator_mock.compare_contest.return_value = _change_set(ChangeType.CREATE)
-    problems = ["p1", "p2"]
-    teams = ["t1", "t2", "t3"]
-
-    service.apply_contest(_contest(problems=problems, teams=teams))
-
-    service._problem_mock.create_many.assert_called_once()
-    service._team_mock.create_many.assert_called_once()
-    assert service._problem_mock.create_many.call_args.args[0] == problems
-    assert service._team_mock.create_many.call_args.args[0] == teams
-
-
-def test_apply_contest_raises_when_problems_fail(service):
-    service._comparator_mock.compare_contest.return_value = _change_set(ChangeType.CREATE)
-    service._problem_mock.get_summary.return_value = {"failed": 2, "succeeded": 1}
-
-    with pytest.raises(ContestError) as exc_info:
-        service.apply_contest(_contest())
-    assert "fail" in str(exc_info.value).lower()
-
-
-def test_apply_contest_raises_when_teams_fail(service):
-    service._comparator_mock.compare_contest.return_value = _change_set(ChangeType.CREATE)
-    service._team_mock.get_summary.return_value = {"failed": 1, "succeeded": 0}
-
-    with pytest.raises(ContestError):
-        service.apply_contest(_contest())
-
-
-def test_apply_contest_wraps_create_error_as_contest_error(service, client):
-    service._comparator_mock.compare_contest.return_value = _change_set(ChangeType.CREATE)
-    client.contests.create.side_effect = RuntimeError("upstream 500")
-
-    with pytest.raises(ContestError) as exc_info:
-        service.apply_contest(_contest())
-    assert "upstream 500" in str(exc_info.value)
-
-
-# ---------------------------------------------------------------- apply orchestration entrypoint
-
-
-def test_apply_all_iterates_over_all_contests(secrets):
-    """The operations-layer orchestrator wires a client and calls the
-    service once per contest. Wiring lives in operations now, not
-    services, so we exercise it from there."""
-    from dom.core.operations.contest.apply import _apply_all
-    from dom.core.operations.framework import Context
-    from dom.core.services.contest.apply import ContestApplyResult
-
-    config = MagicMock()
-    config.infra = MagicMock()
-    config.contests = [_contest("A"), _contest("B"), _contest("C")]
-    ctx = Context(secrets=secrets)
-
-    with (
-        patch("dom.core.operations.contest.apply.wire_admin_api") as wire,
-        patch("dom.core.operations.contest.apply.ContestApplicationService") as service_cls,
-        patch("dom.core.operations.contest.apply.ProblemService"),
-        patch("dom.core.operations.contest.apply.TeamService"),
-        patch("dom.core.operations.contest.apply.ContestStateComparator"),
-    ):
-        instance = MagicMock()
-        instance.apply_contest.side_effect = [
-            ContestApplyResult(contest_shortname=s, contest_id=f"id-{s}") for s in ("A", "B", "C")
-        ]
-        service_cls.return_value = instance
-        wire.return_value = MagicMock()
-
-        results = _apply_all(config, ctx)
-
-    assert instance.apply_contest.call_count == 3
-    assert [r.contest_shortname for r in results] == ["A", "B", "C"]


### PR DESCRIPTION
## Summary

Make the contest operation layer earn its keep by mirroring the infrastructure layer's shape: the **operation owns the workflow**, the **service exposes a flat toolkit**. Previously, `apply_contests_op` was a 3-line wire-up + `for` loop, and the entire workflow lived inside `ContestApplicationService.apply_contest`. After this PR, every `@operation` in `dom.core.operations` follows the same pattern (returns `Steps` for workflows, typed value for queries), and no service method orchestrates more than one external workflow step.

### Operations / services
- `ContestApplicationService` is now a flat toolkit. Public methods: `compare`, `resolve_or_create`, `provision_team_group`, `apply_problems`, `apply_teams`. The `apply_contest` orchestrator and the internal `_run_concurrent` helper are gone.
- `apply_contests_op` returns `Steps`, expanding each contest into five named steps. Per-contest state is threaded across closures via a `_ContestSession` dataclass.
- `plan_contest_changes_op` returns typed `ContestPlan` / `ContestPlanItem` instead of `list[dict[str, Any]]`.
- `ContestChangeSet` gained `existing_contest_id` (populated by the comparator) so apply no longer re-fetches the contest listing.

### Framework
- `Steps` gained an optional `result: Callable[[], Any] | None`. When set, the runner returns its value and the `@operation(summary=...)` callback formats it. This is what lets the multi-step contest apply produce a typed `list[ContestApplyResult]` for the CLI to render warnings.

### Cleanups
- Drop duplicated path-existence guards from `load_config_op`, `load_contest_config_op`, `load_infra_config_op`, `verify_problemset_op`. Loaders already raise `FileNotFoundError` with better context.
- Extract team-group naming convention into a small helper (`_team_group_naming`) instead of inlining the strings.
- Update `dom/core/__init__.py` docstring to reflect the new "services are flat toolkits" rule.

### UX impact
- `dom contest apply --dry-run` now lists the real per-contest steps (`[shortname] Compare state`, `Create or resolve`, `Provision team group`, `Apply problems`, `Apply teams`).
- Per-step progress shows live during apply.

## Test plan

- [x] `pytest tests/unit tests/integration` — 338 passed
- [x] `ruff check dom tests` — clean
- [x] `mypy dom` — clean
- [x] `lint-imports` — all 3 contracts kept (CLI → Operations → Services → Infrastructure; no reverse deps; only CLI may import dom.ui)
- [x] Service tests rewritten: each toolkit method exercised in isolation via constructor injection (no module-level `patch` of collaborators)
- [x] Operation tests verify all five steps fire per contest and that the framework forwards the typed result
- [ ] Smoke test: `dom contest apply --dry-run --verbose -f dom-judge.yaml` against a real config to visually confirm the new step layout