### PR TITLE
chore: bump version to 0.5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "domjudge-cli"
-version = "0.4.2"
+version = "0.5.0"
 description = "CLI tool for managing DOMjudge contests and infrastructure"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary
- Bumps `pyproject.toml` from `0.4.2` to `0.5.0`.

## Test plan
- [ ] CI build passes
- [ ] `pip install .` reports version `0.5.0`