### PR TITLE
fix(validation): allow privileged ports (80/443) by default

### DIFF
--- a/dom/validation/rules.py
+++ b/dom/validation/rules.py
@@ -42,20 +42,23 @@ class ValidationRules:
     # ============================================================
 
     @staticmethod
-    def port(warn_privileged: bool = True) -> ValidatorBuilder:
+    def port(reject_privileged: bool = False) -> ValidatorBuilder:
         """
         Validate port number.
 
         Rules:
         - Must be 1-65535
-        - Warn if < 1024 (requires privileges)
+        - Privileged ports (< 1024) are allowed by default so users can bind
+          80/443 for direct HTTP/HTTPS access. ``dom infra apply`` still
+          emits a runtime warning when a privileged port is used.
 
         Args:
-            warn_privileged: Whether to warn about privileged ports
+            reject_privileged: Hard-reject ports < 1024. Off by default; opt in
+                if you want validation to fail for privileged ports.
         """
         builder = ValidatorBuilder.port()
 
-        if warn_privileged:
+        if reject_privileged:
             builder = builder.unprivileged()
 
         return builder

--- a/tests/unit/validation/test_validation_rules.py
+++ b/tests/unit/validation/test_validation_rules.py
@@ -11,18 +11,14 @@ class TestPortValidation:
 
     def test_valid_ports(self):
         """Test that valid port numbers pass validation."""
-        # By default, warns about privileged ports (< 1024)
+        # Privileged ports (< 1024) are allowed by default so users can bind 80/443.
         validator = ValidationRules.port().build()
 
-        # Test non-privileged ports
+        assert validator("80") == 80
+        assert validator("443") == 443
         assert validator("1024") == 1024
         assert validator("8080") == 8080
         assert validator("65535") == 65535
-
-        # Test with privileged ports allowed
-        validator_with_privileged = ValidationRules.port(warn_privileged=False).build()
-        assert validator_with_privileged("80") == 80
-        assert validator_with_privileged("443") == 443
 
     def test_invalid_ports(self):
         """Test that invalid port numbers fail validation."""
@@ -36,6 +32,15 @@ class TestPortValidation:
 
         with pytest.raises(Invalid):
             validator("-1")
+
+    def test_reject_privileged_opt_in(self):
+        """Opting in to ``reject_privileged`` should hard-reject ports < 1024."""
+        validator = ValidationRules.port(reject_privileged=True).build()
+
+        with pytest.raises(Invalid):
+            validator("80")
+
+        assert validator("1024") == 1024
 
 
 class TestContestNameValidation:


### PR DESCRIPTION
## Summary
- Port validation previously hard-rejected ports < 1024, so users couldn't configure the infra to bind 80 (HTTP) or 443 (HTTPS) directly.
- `ValidationRules.port()` now accepts any valid port (1-65535) by default. The (misleadingly named) `warn_privileged` flag is renamed to `reject_privileged` and is opt-in for callers that want strict rejection.
- `dom infra apply` already emits a runtime warning when a privileged port is used, so users still get a heads-up about needing elevated privileges (sudo / CAP_NET_BIND_SERVICE).

## Test plan
- [x] `pytest tests/unit/validation/test_validation_rules.py` passes (default accepts 80/443; opt-in rejects)
- [ ] Configure infra with `port: 80`, run `dom infra apply`; verify it accepts the value and emits the privileged-port warning
- [ ] Configure infra with `port: 443`; verify acceptance
- [ ] Configure infra with `port: 0` / `65536`; verify validation still rejects